### PR TITLE
Release v3.2.1: Fix login preset crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# Changelog (v3.2.0)
+# Changelog (v3.2.1)
 
-## v3.2.0 — 2026-04-08
+## v3.2.1 — 2026-04-08
+
+### Fixed
+- **Login Preset Crash**: Fixed a critical crash that occurred when logging in with active manual presets. Manual presets are now correctly restored as functional objects during the initialization sequence.
 
 ### Added
 - **Mute & Volume Independence**: Muting a channel while a preset is active no longer locks the slider into "manual override" mode. Mutes behave fully independently, allowing presets to seamlessly take control of standard volume values tracking behind the scenes.

--- a/VolumeSliders/Init.lua
+++ b/VolumeSliders/Init.lua
@@ -467,7 +467,7 @@ initFrame:SetScript("OnEvent", function(self, event)
             local numIdx = tonumber(idx)
             -- Apply "Iron Fist" Rule 10 (Registry Integrity) check
             if db.automation.presets and numIdx and db.automation.presets[numIdx] then
-                VS.session.activeRegistry.manual[numIdx] = true
+                VS.session.activeRegistry.manual[numIdx] = db.automation.presets[numIdx]
                 VS.session.manualActivationTimes[numIdx] = tonumber(timestamp)
             else
                 -- Orphaned index, clean it up

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -2,7 +2,7 @@
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels
-## Version: v3.2.0
+## Version: v3.2.1
 ## SavedVariables: VolumeSlidersMMDB
 ## SavedVariablesPerCharacter:
 ## OptionalDeps:

--- a/spec/LoginRestoration_spec.lua
+++ b/spec/LoginRestoration_spec.lua
@@ -1,0 +1,100 @@
+local assert = require("luassert")
+local spy = require("luassert.spy")
+
+require("spec.setup")
+
+describe("Login Restoration Regression", function()
+    local VS
+    local initFrameScript
+
+    before_each(function()
+        -- Reset global state
+        _G.VolumeSlidersMMDB = {
+            schemaVersion = 5,
+            automation = {
+                presets = {
+                    { name = "Test Preset", priority = 5, volumes = { ["Sound_MasterVolume"] = 0.5 } }
+                },
+                activeManualPresets = { ["1"] = 1000 }, -- Preset 1 is active
+                persistedBaseline = { ["Sound_MasterVolume"] = 1.0 },
+                lastAppliedState = { ["Sound_MasterVolume"] = 1.0 }
+            },
+            minimap = {},
+            layout = { sliderOrder = {}, footerOrder = {} },
+            channels = {},
+            toggles = {},
+            voice = {},
+            hardware = {}
+        }
+        
+        _G.GetCVar = function() return "1.0" end
+        _G.SetCVar = spy.new(function() end)
+        _G.GetTime = function() return 2000 end
+
+        _G.GetRealZoneText = function() return "Elwynn Forest" end
+        _G.GetSubZoneText = function() return "Goldshire" end
+        _G.GetMinimapZoneText = function() return "Lion's Pride Inn" end
+        
+        _G.C_VoiceChat = {
+            GetOutputVolume = function() return 100 end,
+            GetMasterVolumeScale = function() return 1 end,
+            GetInputVolume = function() return 100 end,
+            GetVADSensitivity = function() return 0 end
+        }
+
+        -- Load modules
+        local addonName, addonTable = "VolumeSliders", {}
+        
+        -- Load Core (for constants)
+        loadfile("VolumeSliders/Core.lua")(addonName, addonTable)
+        -- Load Presets (the engine)
+        loadfile("VolumeSliders/Presets.lua")(addonName, addonTable)
+        
+        VS = addonTable
+        VS.InitializeSettings = function() end
+        VS.UpdateMiniMapButtonVisibility = function() end
+        VS.HandlePTT_OnMouseUp = function() end
+        VS.HandlePTT_OnMouseDown = function() end
+        VS.UpdateMiniMapVolumeIcon = function() end
+        VS.HookBrokerScroll = function() end
+        VS.LDBIcon = { Register = function() end }
+        VS.Fishing = { Initialize = function() end }
+        VS.LFGQueue = { Initialize = function() end }
+        VS.VolumeSlidersObject = {}
+        local realCreateFrame = _G.CreateFrame
+        _G.CreateFrame = function()
+            return {
+                RegisterEvent = function() end,
+                UnregisterEvent = function() end,
+                SetScript = function(self, evt, handler)
+                    if evt == "OnEvent" then initFrameScript = handler end
+                end,
+                RegisterForClicks = function() end,
+                EnableMouseWheel = function() end,
+                EnableMouse = function() end,
+                HookScript = function() end
+            }
+        end
+
+        -- Load Init
+        loadfile("VolumeSliders/Init.lua")(addonName, VS)
+        _G.CreateFrame = realCreateFrame
+    end)
+
+    it("should restore manual presets as objects and avoid crashing in EvaluateAllPresets", function()
+        -- Directly trigger PLAYER_LOGIN
+        -- This will trigger RefreshEventState -> OnPresetEvent -> EvaluateAllPresets
+        assert.has_no.errors(function()
+            initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
+        end)
+
+        -- Verify the session state holds the actual preset object
+        local restoredPreset = VS.session.activeRegistry.manual[1]
+        assert.is_table(restoredPreset)
+        assert.are.equal("Test Preset", restoredPreset.name)
+        assert.are.equal(0.5, restoredPreset.volumes["Sound_MasterVolume"])
+        
+        -- Verify that SetCVar was eventually called with the preset volume (0.5)
+        assert.spy(_G.SetCVar).was_called_with("Sound_MasterVolume", 0.5)
+    end)
+end)

--- a/spec/MigrationV5_spec.lua
+++ b/spec/MigrationV5_spec.lua
@@ -89,7 +89,7 @@ describe("Schema V4 to V5 Migration", function()
 
         -- Check session recovery
         assert.is_table(VS.session.activeRegistry.manual)
-        assert.is_true(VS.session.activeRegistry.manual[1])
+        assert.is_table(VS.session.activeRegistry.manual[1])
         assert.are.equal(5000, VS.session.manualActivationTimes[1])
     end)
 


### PR DESCRIPTION
## v3.2.1 — 2026-04-08

### Fixed
- **Login Preset Crash**: Fixed a critical crash that occurred when logging in with active manual presets. Manual presets are now correctly restored as functional objects during the initialization sequence.

### Technical Details
- Corrected restoration loop in `Init.lua` to fetch the actual preset object from `db.automation.presets` instead of assigning a boolean `true`.
- Added unit test `spec/LoginRestoration_spec.lua` to verify the fix and prevent regressions.
- Updated `spec/MigrationV5_spec.lua` to align with the correct registry data types.
- Bumped `VolumeSliders.toc` and `CHANGELOG.md` to `v3.2.1`.

Verified with 0 Luacheck warnings and 100% Busted pass rate (61/61).