### PR TITLE
Release v3.2.2: Preset Priority Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# Changelog (v3.2.1)
+# Changelog (v3.2.2)
+
+## v3.2.2 — 2026-04-11
+
+### Fixed
+- **Preset Priority Inversion**: Fixed a logic bug where automation presets with higher priority (lower numbers) were being incorrectly overwritten by lower-priority ones. Priority 1 now properly overrides Priority 10.
 
 ## v3.2.1 — 2026-04-08
 

--- a/VolumeSliders/Presets.lua
+++ b/VolumeSliders/Presets.lua
@@ -58,11 +58,13 @@ local activeStates = {}
 -- Logic Implementation
 -------------------------------------------------------------------------------
 
---- Sort function for presets based on priority. Higher priority overwrites lower.
+--- Sort function for presets based on priority.
+--- Lower numbers equal higher priority. Sorting descending (>) pushes
+--- highest priority to the end of the array so they are applied last and win.
 local function SortPresetsByPriority(a, b)
     local pA = a.priority or 0
     local pB = b.priority or 0
-    return pA < pB
+    return pA > pB
 end
 
 --- Get current volume for a channel (Standard CVar or Voice API).

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -2,7 +2,7 @@
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels
-## Version: v3.2.1
+## Version: v3.2.2
 ## SavedVariables: VolumeSlidersMMDB
 ## SavedVariablesPerCharacter:
 ## OptionalDeps:


### PR DESCRIPTION
### Release v3.2.2

**Fixed**
- **Preset Priority Inversion**: Fixed a logic bug where automation presets with higher priority (lower numbers) were being incorrectly overwritten by lower-priority ones. Priority 1 now properly overrides Priority 10.

Closes #9