### PR TITLE
Release v3.3.1: Fix Preset Mute Desync & UI Refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# Changelog (v3.3.0)
+# Changelog (v3.3.1)
+
+## v3.3.1 — 2026-04-16
+
+### Fixed
+- **Preset Mute Desync**: Fixed a bug where applying presets would incorrectly mute the Master channel if it had been manually toggled via the minimap right-click action.
+- **Minimap Icon Refresh**: The minimap speaker icon now accurately updates its texture immediately after a preset change or manual mute to reflect the current sound state.
+- **Internal Stability**: Hardened the baseline synchronization engine to prevent type-mismatch loops and improved safety during early game load phases.
 
 ## v3.3.0 — 2026-04-16
 

--- a/VolumeSliders/Core.lua
+++ b/VolumeSliders/Core.lua
@@ -443,8 +443,10 @@ function VS:VolumeSliders_ToggleMute()
     local soundEnabled = GetCVar("Sound_EnableAllSound")
     if soundEnabled == "1" then
         SetCVar("Sound_EnableAllSound", 0)
+        VS:SyncBaseline("Sound_EnableAllSound", "0")
     else
         SetCVar("Sound_EnableAllSound", 1)
+        VS:SyncBaseline("Sound_EnableAllSound", "1")
     end
     VS:UpdateMiniMapVolumeIcon()
 

--- a/VolumeSliders/Core.lua
+++ b/VolumeSliders/Core.lua
@@ -401,12 +401,13 @@ function VS:SyncBaseline(channel, value, isVoiceMuteToggle)
     end
 
     if isMuteCVar then
-        sess.baselineMutes[targetChannel] = value
+        local strValue = tostring(value)
+        sess.baselineMutes[targetChannel] = strValue
         local db = VolumeSlidersMMDB
         if db then
             db.automation = db.automation or {}
             db.automation.persistedBaseline = db.automation.persistedBaseline or {}
-            db.automation.persistedBaseline[targetChannel .. "_Mute"] = value
+            db.automation.persistedBaseline[targetChannel .. "_Mute"] = strValue
         end
     else
         sess.baselineVolumes[targetChannel] = tonumber(value) or 1

--- a/VolumeSliders/Presets.lua
+++ b/VolumeSliders/Presets.lua
@@ -108,7 +108,9 @@ local function RefreshUI()
     if VS.VolumeSlidersObject then
         VS.VolumeSlidersObject.text = VS:GetVolumeText()
     end
-    VS:UpdateMiniMapVolumeIcon()
+    if VS.UpdateMiniMapVolumeIcon then
+        VS:UpdateMiniMapVolumeIcon()
+    end
 end
 
 --- Registers an active preset in the session stack and triggers evaluation.

--- a/VolumeSliders/Presets.lua
+++ b/VolumeSliders/Presets.lua
@@ -108,6 +108,7 @@ local function RefreshUI()
     if VS.VolumeSlidersObject then
         VS.VolumeSlidersObject.text = VS:GetVolumeText()
     end
+    VS:UpdateMiniMapVolumeIcon()
 end
 
 --- Registers an active preset in the session stack and triggers evaluation.

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -2,7 +2,7 @@
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels
-## Version: v3.3.0
+## Version: v3.3.1
 ## SavedVariables: VolumeSlidersMMDB
 ## SavedVariablesPerCharacter:
 ## OptionalDeps:

--- a/spec/Presets_spec.lua
+++ b/spec/Presets_spec.lua
@@ -29,7 +29,7 @@ describe("Registry-based Preset Logic (Unified State Stack)", function()
         _G.setCvarSpy = spy.new(function(name, val) _G.cvarStorage[name] = tostring(val) end)
         _G.SetCVar = _G.setCvarSpy
 
-        local addonName, addonTable = "VolumeSliders", {}
+        local addonName, addonTable = CreateAddonContext()
         loadfile("VolumeSliders/Core.lua")(addonName, addonTable)
         loadfile("VolumeSliders/Presets.lua")(addonName, addonTable)
         

--- a/spec/setup.lua
+++ b/spec/setup.lua
@@ -486,6 +486,7 @@ function CreateAddonContext()
         UpdateAppearance = function() end,
         Reposition = function() end,
         UpdateMiniMapButtonVisibility = function() end,
+        UpdateMiniMapVolumeIcon = function() end,
     }
     return "VolumeSliders", addonTable
 end


### PR DESCRIPTION
## v3.3.1 — 2026-04-16

### Fixed
- **Preset Mute Desync**: Fixed a bug where applying presets would incorrectly mute the Master channel if it had been manually toggled via the minimap right-click action.
- **Minimap Icon Refresh**: The minimap speaker icon now accurately updates its texture immediately after a preset change or manual mute to reflect the current sound state.
- **Internal Stability**: Hardened the baseline synchronization engine to prevent type-mismatch loops and improved safety during early game load phases.