### PR TITLE
Release v3.4.0: Live Tooltip Refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# Changelog (v3.3.1)
+# Changelog (v3.4.0)
+
+## v3.4.0 — 2026-04-16
+
+### Added
+- **Live Tooltip Refresh**: The minimap icon tooltip now updates in real-time as you interact with it. Scroll to adjust volume or click to toggle mutes/presets, and see the changes reflected immediately in the tooltip text without needing to re-hover.
 
 ## v3.3.1 — 2026-04-16
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A World of Warcraft addon that provides quick-access vertical volume sliders for
 - **Two Visual Styles** — Choose the classic ringed button or a "minimalist" speaker icon that automatically fades out when not in use.
 - **Customizable Tooltips** — Use a drag-and-drop list to decide exactly what displays on hover and in what order (Master Volume, Active Presets, Output Device, etc.).
 - **Smart Scroll Wheel** — Scroll over the icon to adjust volume for a selected channel. Configure unique `Shift/Ctrl/Alt` modifiers for additional channels.
+- **Live Tooltip Refresh** — Tooltips now update in real-time as you scroll or click the minimap icon, providing instant visual feedback on volume and state changes.
 - **PTT Shortcut** — Press and hold the minimalist icon to temporarily force "Open Mic" mode if you have Push-to-Talk enabled for the in game voice chat.
 
 ### Automation & Presets

--- a/VolumeSliders/Core.lua
+++ b/VolumeSliders/Core.lua
@@ -625,6 +625,7 @@ function VS:ProcessMinimapAction(triggerStr, clickedFrame, delta)
                     end
                 end
             end
+            VS:RefreshMinimapTooltip()
             return true
         end
     end

--- a/VolumeSliders/MinimapBroker.lua
+++ b/VolumeSliders/MinimapBroker.lua
@@ -121,6 +121,8 @@ VS.VolumeSlidersObject = VS.LDB:NewDataObject("Volume Sliders", {
         elseif button == "RightButton" then
             VS:VolumeSliders_ToggleMute()
         end
+
+        VS:RefreshMinimapTooltip()
     end,
 
     --- Tooltip: dynamic instructions based on configured Mouse Actions.
@@ -221,6 +223,32 @@ function VS:UpdateMiniMapVolumeIcon()
             VS.minimalistButton.minimalistIcon:SetAtlas("voicechat-icon-speaker-mute")
         else
             VS.minimalistButton.minimalistIcon:SetAtlas("voicechat-icon-speaker")
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Tooltip Refresh Helper
+--
+-- Rebuilds the active minimap tooltip if it's currently showing, allowing
+-- real-time updates of volume percentages and preset states after actions.
+-------------------------------------------------------------------------------
+function VS:RefreshMinimapTooltip()
+    -- Case 1: Minimalist button using standard GameTooltip
+    if VS.minimalistButton and GameTooltip:IsShown() and GameTooltip:GetOwner() == VS.minimalistButton then
+        GameTooltip:ClearLines()
+        VS.VolumeSlidersObject.OnTooltipShow(GameTooltip)
+        GameTooltip:Show()
+        return
+    end
+
+    -- Case 2: Standard LibDBIcon button using its private LibDBIconTooltip frame
+    if _G.LibDBIconTooltip and _G.LibDBIconTooltip:IsShown() then
+        local owner = _G.LibDBIconTooltip:GetOwner()
+        if owner and owner.dataObject == VS.VolumeSlidersObject then
+            _G.LibDBIconTooltip:ClearLines()
+            VS.VolumeSlidersObject.OnTooltipShow(_G.LibDBIconTooltip)
+            _G.LibDBIconTooltip:Show()
         end
     end
 end
@@ -383,6 +411,8 @@ function VS:CreateMinimalistButton()
             elseif button == "RightButton" then
                 VS:VolumeSliders_ToggleMute()
             end
+
+            VS:RefreshMinimapTooltip()
         end
     end)
 

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -2,7 +2,7 @@
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels
-## Version: v3.3.1
+## Version: 3.4.0
 ## SavedVariables: VolumeSlidersMMDB
 ## SavedVariablesPerCharacter:
 ## OptionalDeps:


### PR DESCRIPTION
## v3.4.0 — 2026-04-16

### Added
- **Live Tooltip Refresh**: The minimap icon tooltip now updates in real-time as you interact with it. Scroll to adjust volume or click to toggle mutes/presets, and see the changes reflected immediately in the tooltip text without needing to re-hover.