### PR TITLE
Release v3.7.0: Emote Toggle, Patch 12.0.5 Support, and Layout Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Emote Sounds Toggle**: Added a new "Emote Sounds" checkbox to the main popup footer, allowing users to quickly toggle character emote audio (like /laugh or /cry) without opening Blizzard's settings. 
   - *Note*: This is disabled by default. You can enable it via the "Window Settings" configuration panel.
 - **Enriched Automation Tooltips**: Overhauled the tooltips for Zone Triggers, Fishing Boost, and LFG Pop Boost in both the main popup and settings window. Tooltips now explicitly clarify that these automations affect the **Sound Effects (SFX)** channel.
+- **Settings Page Visuals**: Changed the background of all configuration pages from semi-transparent grey to **solid black** for improved contrast and a more premium aesthetic.
 
 ### Technical
 - **Database Schema V7**: Upgraded the internal data persistence layer to Schema V7. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
 # Changelog (v3.7.0)
 
-## v3.7.0 — 2026-04-20
+## v3.7.0 — 2026-04-21
 
 ### Added
+- **WoW Patch 12.0.5 Support**: Updated to maintain compatibility with the latest World of Warcraft patch.
 - **Emote Sounds Toggle**: Added a new "Emote Sounds" checkbox to the main popup footer, allowing users to quickly toggle character emote audio (like /laugh or /cry) without opening Blizzard's settings. 
   - *Note*: This is disabled by default. You can enable it via the "Window Settings" configuration panel.
 - **Enriched Automation Tooltips**: Overhauled the tooltips for Zone Triggers, Fishing Boost, and LFG Pop Boost in both the main popup and settings window. Tooltips now explicitly clarify that these automations affect the **Sound Effects (SFX)** channel.
 - **Settings Page Visuals**: Changed the background of all configuration pages from semi-transparent grey to **solid black** for improved contrast and a more premium aesthetic.
 
+### Fixed
+- **Footer Reordering Persistence**: Fixed a bug where reordering footer elements in the Window Customization settings failed to persist in the main UI until a reload. Direct structural changes now trigger immediate layout recalculations.
+
 ### Technical
 - **Database Schema V7**: Upgraded the internal data persistence layer to Schema V7. 
 - **Automated Migration**: Implemented a seamless migration path that injects the new Emote toggle into existing user layouts while preserving custom footer ordering.
 - **Hardened Testing**: Expanded the unit testing suite to validate structural integrity across the new schema version.
+- **Layout Engine Optimization**: Integrated mandatory `FlagLayoutDirty()` triggers for all structural UI changes to ensure UI geometry remains synchronized with settings.
 
 ## v3.6.1 — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-# Changelog (v3.6.1)
+# Changelog (v3.7.0)
+
+## v3.7.0 — 2026-04-20
+
+### Added
+- **Emote Sounds Toggle**: Added a new "Emote Sounds" checkbox to the main popup footer, allowing users to quickly toggle character emote audio (like /laugh or /cry) without opening Blizzard's settings. 
+  - *Note*: This is disabled by default. You can enable it via the "Window Settings" configuration panel.
+- **Enriched Automation Tooltips**: Overhauled the tooltips for Zone Triggers, Fishing Boost, and LFG Pop Boost in both the main popup and settings window. Tooltips now explicitly clarify that these automations affect the **Sound Effects (SFX)** channel.
+
+### Technical
+- **Database Schema V7**: Upgraded the internal data persistence layer to Schema V7. 
+- **Automated Migration**: Implemented a seamless migration path that injects the new Emote toggle into existing user layouts while preserving custom footer ordering.
+- **Hardened Testing**: Expanded the unit testing suite to validate structural integrity across the new schema version.
 
 ## v3.6.1 — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,10 @@
 - **Emote Sounds Toggle**: Added a new "Emote Sounds" checkbox to the main popup footer, allowing users to quickly toggle character emote audio (like /laugh or /cry) without opening Blizzard's settings. 
   - *Note*: This is disabled by default. You can enable it via the "Window Settings" configuration panel.
 - **Enriched Automation Tooltips**: Overhauled the tooltips for Zone Triggers, Fishing Boost, and LFG Pop Boost in both the main popup and settings window. Tooltips now explicitly clarify that these automations affect the **Sound Effects (SFX)** channel.
-- **Settings Page Visuals**: Changed the background of all configuration pages from semi-transparent grey to **solid black** for improved contrast and a more premium aesthetic.
+- **Settings Page Visuals**: Changed the background of all configuration pages from semi-transparent grey to **solid black** for less visual noise.
 
 ### Fixed
 - **Footer Reordering Persistence**: Fixed a bug where reordering footer elements in the Window Customization settings failed to persist in the main UI until a reload. Direct structural changes now trigger immediate layout recalculations.
-
-### Technical
-- **Database Schema V7**: Upgraded the internal data persistence layer to Schema V7. 
-- **Automated Migration**: Implemented a seamless migration path that injects the new Emote toggle into existing user layouts while preserving custom footer ordering.
-- **Hardened Testing**: Expanded the unit testing suite to validate structural integrity across the new schema version.
-- **Layout Engine Optimization**: Integrated mandatory `FlagLayoutDirty()` triggers for all structural UI changes to ensure UI geometry remains synchronized with settings.
 
 ## v3.6.1 — 2026-04-17
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Quick-access vertical volume sliders for every WoW sound channel, right from your minimap.
 
-![WoW](https://img.shields.io/badge/WoW-12.0.1-blue)
+![WoW](https://img.shields.io/badge/WoW-12.0.5-blue)
 ![License](https://img.shields.io/badge/license-All%20Rights%20Reserved-lightgrey)
 
 <p align="center">

--- a/VolumeSliders/Appearance.lua
+++ b/VolumeSliders/Appearance.lua
@@ -434,6 +434,8 @@ function VS:UpdateAppearance()
     local lowSelected   = db.appearance.lowColor or 2
 
     -- Dynamically resize the main popup frame if it exists
+    -- Performance: Only recalculate anchors/geometry if the layout is flagged as dirty.
+    -- If adding/removing elements or changing order, you MUST call VS:FlagLayoutDirty().
     if VS.container and VS.session.layoutDirty then
 
         local containerW = VS.container:GetWidth()
@@ -591,7 +593,9 @@ end
 
 -------------------------------------------------------------------------------
 --- Flag the layout as needing a full recalculation.
--- If the container is currently visible, it triggers an immediate update.
+--- If the container is currently visible, it triggers an immediate update.
+--- REQUIRED for structural changes (adding/removing sliders, reordering, visibility toggles).
+--- Failure to call this will cause UpdateAppearance to skip geometry recalculations.
 function VS:FlagLayoutDirty()
     VS.session.layoutDirty = true
     if VS.container and VS.container:IsShown() then

--- a/VolumeSliders/Appearance.lua
+++ b/VolumeSliders/Appearance.lua
@@ -285,6 +285,7 @@ function VS:UpdateFooterLayout()
         ["showLfgPop"]        = { frame = VS.lfgCheck,               label = VS.lfgCheck and VS.lfgCheck.labelText },
         ["showCharacter"]     = { frame = VS.characterCheckbox,      label = VS.characterCheckbox and VS.characterCheckbox.labelText },
         ["showBackground"]    = { frame = VS.backgroundCheckbox,     label = VS.backgroundCheckbox and VS.backgroundCheckbox.labelText },
+        ["showEmoteSounds"]   = { frame = VS.emoteSoundsCheckbox,    label = VS.emoteSoundsCheckbox and VS.emoteSoundsCheckbox.labelText },
         ["showOutput"]        = { frame = VS.outputDropdown },
         ["showVoiceMode"]     = { frame = VS.voiceModeBtn },
     }

--- a/VolumeSliders/Core.lua
+++ b/VolumeSliders/Core.lua
@@ -260,7 +260,7 @@ VS.DEFAULT_DB = {
         showHelpText = true,
         showMinimapTooltip = true,
         showVoiceMode = true,
-        showEmoteSounds = true,
+        showEmoteSounds = false,
         persistentWindow = false,
         isLocked = false,
     },

--- a/VolumeSliders/Core.lua
+++ b/VolumeSliders/Core.lua
@@ -185,9 +185,9 @@ VS.DEFAULT_FOOTER_ORDER = {
     "showLfgPop",
     "showCharacter",
     "showBackground",
+    "showEmoteSounds",
     "showOutput",
     "showVoiceMode",
-    "showEmoteSounds",
 }
 
 -------------------------------------------------------------------------------

--- a/VolumeSliders/Core.lua
+++ b/VolumeSliders/Core.lua
@@ -187,6 +187,7 @@ VS.DEFAULT_FOOTER_ORDER = {
     "showBackground",
     "showOutput",
     "showVoiceMode",
+    "showEmoteSounds",
 }
 
 -------------------------------------------------------------------------------
@@ -215,7 +216,7 @@ VS.DEFAULT_FOOTER_ORDER = {
 --- @field voice table
 
 VS.DEFAULT_DB = {
-    schemaVersion = 6,
+    schemaVersion = 7,
     
     appearance = {
         bgColor = { r = 0.05, g = 0.05, b = 0.05, a = 0.95 },
@@ -259,6 +260,7 @@ VS.DEFAULT_DB = {
         showHelpText = true,
         showMinimapTooltip = true,
         showVoiceMode = true,
+        showEmoteSounds = true,
         persistentWindow = false,
         isLocked = false,
     },

--- a/VolumeSliders/Init.lua
+++ b/VolumeSliders/Init.lua
@@ -346,6 +346,35 @@ local function Migrate_V5_to_V6(db)
 end
 
 -------------------------------------------------------------------------------
+-- V6 -> V7 Schema Migration Engine
+--
+-- Injects the "showEmoteSounds" toggle into the footerOrder array for existing
+-- users. The dictionary-level default is handled by MergeTable.
+--
+-- @param db table The VolumeSlidersMMDB global table.
+-------------------------------------------------------------------------------
+local function Migrate_V6_to_V7(db)
+    if db.schemaVersion and db.schemaVersion >= 7 then return end
+
+    db.layout = db.layout or {}
+    db.layout.footerOrder = db.layout.footerOrder or {}
+
+    -- Inject "showEmoteSounds" if missing
+    local found = false
+    for _, key in ipairs(db.layout.footerOrder) do
+        if key == "showEmoteSounds" then
+            found = true
+            break
+        end
+    end
+    if not found then
+        table.insert(db.layout.footerOrder, 6, "showEmoteSounds")
+    end
+
+    db.schemaVersion = 7
+end
+
+-------------------------------------------------------------------------------
 -- Main Event Handler (PLAYER_LOGIN)
 --
 -- Orchestrates the addon bootstrap sequence:
@@ -364,6 +393,7 @@ initFrame:SetScript("OnEvent", function(self, event)
     Migrate_V3_to_V4(db)
     Migrate_V4_to_V5(db)
     Migrate_V5_to_V6(db)
+    Migrate_V6_to_V7(db)
     
     -- Smart Auto-Detection for Minimalist Minimap Icon
     -- We do this BEFORE MergeTable to ensure detection sets the "Smart Default"

--- a/VolumeSliders/PopupFrame.lua
+++ b/VolumeSliders/PopupFrame.lua
@@ -566,7 +566,7 @@ function VS:CreateOptionsFrame()
     end, function()
         return db.automation.enableTriggers == true
     end)
-    AddTooltip(VS.triggerCheck, "Automatically adjust volume levels when entering zones designated in your presets.")
+    AddTooltip(VS.triggerCheck, "Automatically adjust volume levels when entering zones designated in your presets.\n\nPresets can override any audio channel.")
 
     VS.fishingCheck = VS:CreateCheckbox(VS.contentFrame, "VolumeSlidersCheckFishing", "Fishing Boost", function(checked)
         db.automation.enableFishingVolume = checked
@@ -576,7 +576,7 @@ function VS:CreateOptionsFrame()
     end, function()
         return db.automation.enableFishingVolume == true
     end)
-    AddTooltip(VS.fishingCheck, "Temporarily overrides volumes while fishing so you can hear the splash.")
+    AddTooltip(VS.fishingCheck, "Temporarily overrides volumes while fishing so you can hear the splash.\n\nThe bobber splash plays through Sound Effects (SFX).")
 
     VS.lfgCheck = VS:CreateCheckbox(VS.contentFrame, "VolumeSlidersCheckLFG", "LFG Pop Boost", function(checked)
         db.automation.enableLfgVolume = checked
@@ -586,7 +586,7 @@ function VS:CreateOptionsFrame()
     end, function()
         return db.automation.enableLfgVolume == true
     end)
-    AddTooltip(VS.lfgCheck, "Temporarily overrides volumes when the Dungeon Ready prompt appears.")
+    AddTooltip(VS.lfgCheck, "Temporarily overrides volumes when the Dungeon Ready prompt appears.\n\nThe queue pop plays through Sound Effects (SFX).")
 
     -- "Sound at Character" checkbox â€” toggles whether the listener position
     -- is at the player's character or at the camera.
@@ -615,6 +615,17 @@ function VS:CreateOptionsFrame()
     -- Initial anchor, will be refined in the C_Timer block
     VS.backgroundCheckbox:SetPoint("TOPLEFT", VS.characterCheckbox, "BOTTOMLEFT", 0, -2)
     AddTooltip(VS.backgroundCheckbox, "Continue playing audio even when the game is minimized or not the active window.")
+
+    VS.emoteSoundsCheckbox = VS:CreateCheckbox(VS.contentFrame, "VolumeSlidersCheckEmote", "Emote Sounds", function(checked)
+        if checked then
+            SetCVar("Sound_EnableEmoteSounds", 1)
+        else
+            SetCVar("Sound_EnableEmoteSounds", 0)
+        end
+    end, function()
+        return GetCVar("Sound_EnableEmoteSounds") == "1"
+    end)
+    AddTooltip(VS.emoteSoundsCheckbox, "Toggle whether character emote sounds are played (e.g., /laugh, /cry).")
 
     ---------------------------------------------------------------------------
     -- Sound Output Device Dropdown

--- a/VolumeSliders/Settings_Automation.lua
+++ b/VolumeSliders/Settings_Automation.lua
@@ -48,7 +48,7 @@ function VS:CreateAutomationSettingsContents(parentFrame)
         end
         PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
     end)
-    VS:AddTooltip(enableCheck, "Automatically adjust volume levels when entering zones designated in your presets. Original volumes are restored when leaving the area.")
+    VS:AddTooltip(enableCheck, "Automatically adjust volume levels when entering zones designated in your presets.\n\nPresets can override any audio channel.")
 
     local fishingCheck = CreateFrame("CheckButton", nil, contentFrame, "UICheckButtonTemplate")
     fishingCheck:SetPoint("TOPLEFT", enableCheck, "TOPRIGHT", 180, 0)
@@ -63,7 +63,7 @@ function VS:CreateAutomationSettingsContents(parentFrame)
         end
         PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
     end)
-    VS:AddTooltip(fishingCheck, "Temporarily overrides volumes while fishing so you can clearly hear the bobber splash. Disabled during combat.")
+    VS:AddTooltip(fishingCheck, "Temporarily overrides volumes while fishing so you can hear the splash.\n\nThe bobber splash plays through Sound Effects (SFX).")
 
     local lfgCheck = CreateFrame("CheckButton", nil, contentFrame, "UICheckButtonTemplate")
     lfgCheck:SetPoint("TOPLEFT", enableCheck, "BOTTOMLEFT", 0, -5)
@@ -78,7 +78,7 @@ function VS:CreateAutomationSettingsContents(parentFrame)
         end
         PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
     end)
-    VS:AddTooltip(lfgCheck, "Temporarily overrides volumes when the Dungeon Ready prompt appears.")
+    VS:AddTooltip(lfgCheck, "Temporarily overrides volumes when the Dungeon Ready prompt appears.\n\nThe queue pop plays through Sound Effects (SFX).")
 
     local deviceVolumesCheck = CreateFrame("CheckButton", nil, contentFrame, "UICheckButtonTemplate")
     deviceVolumesCheck:SetPoint("TOPLEFT", fishingCheck, "BOTTOMLEFT", 0, -5)

--- a/VolumeSliders/Settings_Automation.lua
+++ b/VolumeSliders/Settings_Automation.lua
@@ -11,7 +11,7 @@ function VS:CreateAutomationSettingsContents(parentFrame)
 
     local bg = scrollFrame:CreateTexture(nil, "BACKGROUND")
     bg:SetAllPoints()
-    bg:SetColorTexture(0.02, 0.02, 0.02, 0.5)
+    bg:SetColorTexture(0, 0, 0, 1)
 
     local contentFrame = CreateFrame("Frame", "VSAutomationSettingsContentFrame", scrollFrame)
     contentFrame:SetSize(600, 800)

--- a/VolumeSliders/Settings_Main.lua
+++ b/VolumeSliders/Settings_Main.lua
@@ -129,7 +129,7 @@ function VS:CreateSettingsContents(parentFrame)
 
     local bg = scrollFrame:CreateTexture(nil, "BACKGROUND")
     bg:SetAllPoints()
-    bg:SetColorTexture(0.02, 0.02, 0.02, 0.5)
+    bg:SetColorTexture(0, 0, 0, 1)
 
     local categoryFrame = CreateFrame("Frame", "VolumeSlidersSettingsContentFrame", scrollFrame)
     categoryFrame:SetSize(600, 250)

--- a/VolumeSliders/Settings_Minimap.lua
+++ b/VolumeSliders/Settings_Minimap.lua
@@ -40,7 +40,7 @@ function VS:CreateMinimapSettingsContents(parentFrame)
 
     local bg = scrollFrame:CreateTexture(nil, "BACKGROUND")
     bg:SetAllPoints()
-    bg:SetColorTexture(0.02, 0.02, 0.02, 0.5)
+    bg:SetColorTexture(0, 0, 0, 1)
 
     local categoryFrame = CreateFrame("Frame", "VSMinimapSettingsContentFrame", scrollFrame)
     categoryFrame:SetSize(600, 700)

--- a/VolumeSliders/Settings_MouseActions.lua
+++ b/VolumeSliders/Settings_MouseActions.lua
@@ -52,7 +52,7 @@ function VS:CreateMouseActionsSettingsContents(parentFrame)
 
     local bg = scrollFrame:CreateTexture(nil, "BACKGROUND")
     bg:SetAllPoints()
-    bg:SetColorTexture(0.02, 0.02, 0.02, 0.5)
+    bg:SetColorTexture(0, 0, 0, 1)
 
     local contentFrame = CreateFrame("Frame", "VSMouseActionsSettingsContentFrame", scrollFrame)
     contentFrame:SetSize(600, 800)

--- a/VolumeSliders/Settings_Sliders.lua
+++ b/VolumeSliders/Settings_Sliders.lua
@@ -292,7 +292,8 @@ function VS:CreateSlidersSettingsContents(parentFrame)
 
         checkbox:SetScript("OnClick", function(self)
             db[data.namespace][data.var] = self:GetChecked()
-            VS:UpdateAppearance()
+            -- Visibility change: Must flag dirty so total window height is recalculated
+            VS:FlagLayoutDirty()
         end)
 
         -- Add tooltip support

--- a/VolumeSliders/Settings_Sliders.lua
+++ b/VolumeSliders/Settings_Sliders.lua
@@ -38,7 +38,7 @@ function VS:CreateSlidersSettingsContents(parentFrame)
 
     local bg = scrollFrame:CreateTexture(nil, "BACKGROUND")
     bg:SetAllPoints()
-    bg:SetColorTexture(0.02, 0.02, 0.02, 0.5)
+    bg:SetColorTexture(0, 0, 0, 1)
 
     local categoryFrame = CreateFrame("Frame", "VolumeSlidersSlidersSettingsContentFrame", scrollFrame)
     categoryFrame:SetSize(600, 450)

--- a/VolumeSliders/Settings_Window.lua
+++ b/VolumeSliders/Settings_Window.lua
@@ -43,7 +43,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
 
     local bg = scrollFrame:CreateTexture(nil, "BACKGROUND")
     bg:SetAllPoints()
-    bg:SetColorTexture(0.02, 0.02, 0.02, 0.5)
+    bg:SetColorTexture(0, 0, 0, 1)
 
     local categoryFrame = CreateFrame("Frame", "VolumeSlidersWindowSettingsContentFrame", scrollFrame)
     categoryFrame:SetSize(600, 650)

--- a/VolumeSliders/Settings_Window.lua
+++ b/VolumeSliders/Settings_Window.lua
@@ -196,7 +196,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     helpTextCheck:SetChecked(db.toggles.showHelpText ~= false)
     helpTextCheck:SetScript("OnClick", function(self)
         db.toggles.showHelpText = self:GetChecked()
-        VS:UpdateAppearance()
+        VS:FlagLayoutDirty()
     end)
     VS:AddTooltip(helpTextCheck, "Show or hide the help instructions at the top.")
 
@@ -206,7 +206,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     presetCheck:SetChecked(db.toggles.showPresetsDropdown ~= false)
     presetCheck:SetScript("OnClick", function(self)
         db.toggles.showPresetsDropdown = self:GetChecked()
-        VS:UpdateAppearance()
+        VS:FlagLayoutDirty()
     end)
     VS:AddTooltip(presetCheck, "Show or hide the quick-apply presets dropdown at the top.")
 
@@ -362,7 +362,8 @@ function VS:CreateWindowSettingsContents(parentFrame)
         for _, cvar in dp:EnumerateEntireRange() do
             table_insert(db.layout.sliderOrder, cvar)
         end
-        VS:UpdateAppearance()
+        -- Structural change: Must flag dirty so geometry/order is recalculated next show
+        VS:FlagLayoutDirty()
     end)
 
     local function RefreshDataProvider()
@@ -387,7 +388,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     limitFooterCheck:SetChecked(db.layout.limitFooterCols)
     limitFooterCheck:SetScript("OnClick", function(self)
         db.layout.limitFooterCols = self:GetChecked()
-        VS:UpdateAppearance()
+        VS:FlagLayoutDirty()
     end)
     VS:AddTooltip(limitFooterCheck, "Restrict the maximum number of items allowed per row in the footer.")
 
@@ -548,7 +549,8 @@ function VS:CreateWindowSettingsContents(parentFrame)
         for _, key in dp:EnumerateEntireRange() do
             table_insert(db.layout.footerOrder, key)
         end
-        VS:UpdateAppearance()
+        -- Structural change: Must flag dirty so footer layout is recalculated next show
+        VS:FlagLayoutDirty()
     end)
 
     local function RefreshFooterDataProvider()

--- a/VolumeSliders/Settings_Window.lua
+++ b/VolumeSliders/Settings_Window.lua
@@ -431,6 +431,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
         ["showLfgPop"] = { name = "LFG Pop Boost", namespace = "toggles", tooltip = "Show or hide the LFG Pop Boost toggle." },
         ["showBackground"] = { name = "SBG Checkbox", namespace = "toggles", tooltip = "Show or hide the 'Sound in Background' toggle." },
         ["showCharacter"] = { name = "Char Checkbox", namespace = "toggles", tooltip = "Show or hide the 'Sound at Character' toggle." },
+        ["showEmoteSounds"] = { name = "Emote Sounds", namespace = "toggles", tooltip = "Show or hide the 'Emote Sounds' toggle." },
         ["showOutput"] = { name = "Output Selector", namespace = "toggles", tooltip = "Show or hide the 'Output:' dropdown." },
         ["showVoiceMode"] = { name = "Voice Mode", namespace = "toggles", tooltip = "Show or hide the Voice Chat Mode toggle." },
     }

--- a/VolumeSliders/Settings_Window.lua
+++ b/VolumeSliders/Settings_Window.lua
@@ -46,7 +46,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     bg:SetColorTexture(0, 0, 0, 1)
 
     local categoryFrame = CreateFrame("Frame", "VolumeSlidersWindowSettingsContentFrame", scrollFrame)
-    categoryFrame:SetSize(600, 650)
+    categoryFrame:SetSize(600, 850)
     scrollFrame:SetScrollChild(categoryFrame)
 
     -- Initial dummy resize, overwritten at end of function for dynamic columns
@@ -69,7 +69,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     -- Deduped: Now using shared VS:AddTooltip(frame, text)
 
     local windowBehaviorLabel = categoryFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
-    windowBehaviorLabel:SetPoint("TOPLEFT", desc, "BOTTOMLEFT", 245, -20)
+    windowBehaviorLabel:SetPoint("TOPLEFT", desc, "BOTTOMLEFT", 15, -20)
     windowBehaviorLabel:SetText("Window Behavior")
 
     local persistentCheck = CreateFrame("CheckButton", nil, categoryFrame, "UICheckButtonTemplate")
@@ -84,7 +84,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     local persistentDivider = categoryFrame:CreateTexture(nil, "ARTWORK")
     persistentDivider:SetHeight(1)
     persistentDivider:SetPoint("TOPLEFT", persistentCheck, "BOTTOMLEFT", -20, -15)
-    persistentDivider:SetWidth(400)
+    persistentDivider:SetWidth(560)
     persistentDivider:SetColorTexture(1, 1, 1, 0.2)
 
     ---------------------------------------------------------------------------
@@ -175,14 +175,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     end)
     VS:AddTooltip(opacitySlider, "Adjust the background opacity of the slider window.\n0% = fully transparent, 100% = fully opaque")
 
-    ---------------------------------------------------------------------------
-    -- Vertical Divider
-    ---------------------------------------------------------------------------
-    local dividerV = categoryFrame:CreateTexture(nil, "ARTWORK")
-    dividerV:SetWidth(1)
-    dividerV:SetPoint("TOPLEFT", desc, "BOTTOMLEFT", 220, -10)
-    dividerV:SetPoint("BOTTOMLEFT", categoryFrame, "TOPLEFT", 220, -600)
-    dividerV:SetColorTexture(1, 1, 1, 0.2)
+
 
     ---------------------------------------------------------------------------
     -- Visibility Checkboxes (Window Header Elements)
@@ -190,7 +183,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     local dividerBgH = categoryFrame:CreateTexture(nil, "ARTWORK")
     dividerBgH:SetHeight(1)
     dividerBgH:SetPoint("TOPLEFT", bgColorLabel, "BOTTOMLEFT", -25, -45)
-    dividerBgH:SetWidth(400)
+    dividerBgH:SetWidth(560)
     dividerBgH:SetColorTexture(1, 1, 1, 0.2)
 
     local headerElementsLabel = categoryFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
@@ -220,14 +213,23 @@ function VS:CreateWindowSettingsContents(parentFrame)
     local dividerH = categoryFrame:CreateTexture(nil, "ARTWORK")
     dividerH:SetHeight(1)
     dividerH:SetPoint("TOPLEFT", headerElementsLabel, "BOTTOMLEFT", -25, -45)
-    dividerH:SetWidth(400)
+    dividerH:SetWidth(560)
     dividerH:SetColorTexture(1, 1, 1, 0.2)
+
+    ---------------------------------------------------------------------------
+    -- Vertical Divider (bottom section column separator)
+    ---------------------------------------------------------------------------
+    local dividerV = categoryFrame:CreateTexture(nil, "ARTWORK")
+    dividerV:SetWidth(1)
+    dividerV:SetPoint("TOPLEFT", dividerH, "BOTTOMLEFT", 275, -5)
+    dividerV:SetPoint("BOTTOMLEFT", dividerH, "BOTTOMLEFT", 275, -520)
+    dividerV:SetColorTexture(1, 1, 1, 0.2)
 
     ---------------------------------------------------------------------------
     -- Channel Visibility
     ---------------------------------------------------------------------------
     local channelLabel = categoryFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
-    channelLabel:SetPoint("TOPLEFT", desc, "BOTTOMLEFT", 15, -20)
+    channelLabel:SetPoint("TOPLEFT", dividerH, "BOTTOMLEFT", 25, -20)
     channelLabel:SetText("Channel Visibility")
 
     local channelSubLabel = categoryFrame:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
@@ -251,7 +253,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     }
 
     local scrollBox = CreateFrame("Frame", nil, categoryFrame, "WowScrollBoxList")
-    scrollBox:SetSize(145, 480)
+    scrollBox:SetSize(230, 480)
     scrollBox:SetPoint("TOPLEFT", channelSubLabel, "BOTTOMLEFT", -5, -8)
 
     local dragBehavior -- Forward declare for access in RowInitializer
@@ -343,7 +345,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
 
     dragBehavior:SetDropEnter(function(factory, candidate)
         local frame = factory("VolumeSlidersDropIndicatorTemplate")
-        frame:SetSize(150, 3)
+        frame:SetSize(230, 3)
         if candidate.area == DragIntersectionArea.Above then
             frame:SetPoint("BOTTOMLEFT", candidate.frame, "TOPLEFT", 0, 1)
             frame:SetPoint("BOTTOMRIGHT", candidate.frame, "TOPRIGHT", 0, 1)
@@ -380,7 +382,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     if db.layout.maxFooterCols == nil then db.layout.maxFooterCols = 3 end
 
     local limitFooterCheck = CreateFrame("CheckButton", nil, categoryFrame, "UICheckButtonTemplate")
-    limitFooterCheck:SetPoint("TOPLEFT", dividerH, "BOTTOMLEFT", 25, -15)
+    limitFooterCheck:SetPoint("TOPLEFT", dividerH, "BOTTOMLEFT", 300, -20)
     limitFooterCheck.text:SetText("Limit Footer Columns")
     limitFooterCheck:SetChecked(db.layout.limitFooterCols)
     limitFooterCheck:SetScript("OnClick", function(self)
@@ -437,7 +439,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
     }
 
     local footerBox = CreateFrame("Frame", nil, categoryFrame, "WowScrollBoxList")
-    footerBox:SetSize(145, 230)
+    footerBox:SetSize(230, 280)
     footerBox:SetPoint("TOPLEFT", footerSubLabel, "BOTTOMLEFT", -5, -8)
 
     local footerDragBehavior
@@ -529,7 +531,7 @@ function VS:CreateWindowSettingsContents(parentFrame)
 
     footerDragBehavior:SetDropEnter(function(factory, candidate)
         local frame = factory("VolumeSlidersDropIndicatorTemplate")
-        frame:SetSize(150, 3)
+        frame:SetSize(230, 3)
         if candidate.area == DragIntersectionArea.Above then
             frame:SetPoint("BOTTOMLEFT", candidate.frame, "TOPLEFT", 0, 1)
             frame:SetPoint("BOTTOMRIGHT", candidate.frame, "TOPRIGHT", 0, 1)

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -2,7 +2,7 @@
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels
-## Version: 3.6.1
+## Version: 3.7.0
 ## SavedVariables: VolumeSlidersMMDB
 ## SavedVariablesPerCharacter:
 ## OptionalDeps:

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -1,4 +1,4 @@
-## Interface: 120005
+## Interface: 120001, 120005
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120005
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels

--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -3,7 +3,7 @@
 **Database:** `VolumeSlidersMMDB`
 **Scope:** Global / Account-wide
 **Format:** Serialized Lua Table (Pseudo-JSON representation below)
-**Last Audited:** 2026-03-30 (V2 Namespace Migration)
+**Last Audited:** 2026-04-20 (V7 Emote Toggle)
 
 This document defines the exact shape of the saved variables used by Volume Sliders. It acts as the single source of truth for the data layer, distinguishing between user-configurable options, transient session states, and deprecated keys.
 
@@ -255,10 +255,10 @@ Initializes the `automation.persistedBaseline` and `automation.lastAppliedState`
 
 Tears down the deprecated snapshot-based `manualToggleState` payload system in favor of the stateless, timestamp-based unified stack model. The `db.automation.manualToggleState` table is destroyed unconditionally. A new tracking map, `db.automation.activeManualPresets`, is initialized to persist session-to-session manual preset activation and stack order.
 
-## Migration Contract (Init.lua:Migrate_V5_to_V6)
+## Migration Contract (`Init.lua:Migrate_V5_to_V6`)
 
 Adds the `automation.enableDeviceVolumes` flag to support per-hardware-output-device master volume tracking. For existing users upgrading to V6, this is set to `true` by default to preserve the legacy behavior of the addon, but can now be disabled via the Automation settings panel.
 
-## Migration Contract (Init.lua:Migrate_V6_to_V7)
+## Migration Contract (`Init.lua:Migrate_V6_to_V7`)
 
-Adds the `showEmoteSounds` toggle to the `toggles` namespace and injects it into the `footerOrder` array for existing users. This ensures the new Emote Sounds checkbox is visible in the main popup footer by default upon upgrade.
+Adds the `showEmoteSounds` toggle to the `toggles` namespace and injects it into the `footerOrder` array for existing users. By default, this toggle is set to `false`, meaning it remains hidden from the main popup footer until manually enabled via the settings window.

--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -3,7 +3,7 @@
 **Database:** `VolumeSlidersMMDB`
 **Scope:** Global / Account-wide
 **Format:** Serialized Lua Table (Pseudo-JSON representation below)
-**Last Audited:** 2026-04-20 (V7 Emote Toggle)
+**Last Audited:** 2026-03-30 (V2 Namespace Migration)
 
 This document defines the exact shape of the saved variables used by Volume Sliders. It acts as the single source of truth for the data layer, distinguishing between user-configurable options, transient session states, and deprecated keys.
 

--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -15,7 +15,7 @@ As of version 3.0.0, the monolithic flat-key structure has been deprecated in fa
 
 ```json
 {
-  "schemaVersion": 6,
+  "schemaVersion": 7,
 
   // ---------------------------------------------------------
   // 1. APPEARANCE & WINDOW STYLING
@@ -105,6 +105,7 @@ As of version 3.0.0, the monolithic flat-key structure has been deprecated in fa
     "showZoneTriggers": "boolean",   // Shows Zone Triggers toggle in footer
     "showFishingSplash": "boolean",  // Shows Fishing Splash Boost toggle in footer
     "showHelpText": "boolean",       // Shows help instructions in header
+    "showEmoteSounds": "boolean",    // Shows Emote Sounds toggle in footer
     "showVoiceMode": "boolean"       // Shows Voice Chat Mode toggle in footer
   },
 
@@ -254,6 +255,10 @@ Initializes the `automation.persistedBaseline` and `automation.lastAppliedState`
 
 Tears down the deprecated snapshot-based `manualToggleState` payload system in favor of the stateless, timestamp-based unified stack model. The `db.automation.manualToggleState` table is destroyed unconditionally. A new tracking map, `db.automation.activeManualPresets`, is initialized to persist session-to-session manual preset activation and stack order.
 
-## Migration Contract (`Init.lua:Migrate_V5_to_V6`)
+## Migration Contract (Init.lua:Migrate_V5_to_V6)
 
 Adds the `automation.enableDeviceVolumes` flag to support per-hardware-output-device master volume tracking. For existing users upgrading to V6, this is set to `true` by default to preserve the legacy behavior of the addon, but can now be disabled via the Automation settings panel.
+
+## Migration Contract (Init.lua:Migrate_V6_to_V7)
+
+Adds the `showEmoteSounds` toggle to the `toggles` namespace and injects it into the `footerOrder` array for existing users. This ensures the new Emote Sounds checkbox is visible in the main popup footer by default upon upgrade.

--- a/spec/MigrationV7_spec.lua
+++ b/spec/MigrationV7_spec.lua
@@ -23,7 +23,7 @@ describe("Schema V6 to V7 Migration", function()
             CHANNEL_MUTE_CVAR = { ["Sound_MasterVolume"] = "Sound_EnableAllSound" },
             DEFAULT_DB = {
                 schemaVersion = 7,
-                toggles = { showEmoteSounds = true },
+                toggles = { showEmoteSounds = false },
                 layout = { 
                     footerOrder = { "showZoneTriggers", "showFishingSplash", "showLfgPop", "showBackground", "showCharacter", "showEmoteSounds", "showOutput", "showVoiceMode" }
                 }
@@ -86,7 +86,7 @@ describe("Schema V6 to V7 Migration", function()
         initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
 
         assert.are.equal(7, db.schemaVersion)
-        assert.is_true(db.toggles.showEmoteSounds)
+        assert.is_false(db.toggles.showEmoteSounds)
         
         -- Check if it was injected at index 6 (before showOutput)
         assert.are.equal("showEmoteSounds", db.layout.footerOrder[6])

--- a/spec/MigrationV7_spec.lua
+++ b/spec/MigrationV7_spec.lua
@@ -1,9 +1,9 @@
 -------------------------------------------------------------------------------
--- spec/MigrationV6_spec.lua
--- Isolated unit test for the Schema V6 migration path.
+-- spec/MigrationV7_spec.lua
+-- Isolated unit test for the Schema V7 migration path (Emote Sounds).
 -------------------------------------------------------------------------------
 
-describe("Schema V5 to V6 Migration", function()
+describe("Schema V6 to V7 Migration", function()
     local VS
     local initFrameScript
 
@@ -23,13 +23,12 @@ describe("Schema V5 to V6 Migration", function()
             CHANNEL_MUTE_CVAR = { ["Sound_MasterVolume"] = "Sound_EnableAllSound" },
             DEFAULT_DB = {
                 schemaVersion = 7,
-                automation = { 
-                    enableDeviceVolumes = true,
-                    activeManualPresets = {} 
-                },
-                minimap = { minimalistMinimap = true },
-                layout = { sliderOrder = {}, footerOrder = {} }
+                toggles = { showEmoteSounds = true },
+                layout = { 
+                    footerOrder = { "showZoneTriggers", "showFishingSplash", "showLfgPop", "showBackground", "showCharacter", "showEmoteSounds", "showOutput", "showVoiceMode" }
+                }
             },
+            DEFAULT_FOOTER_ORDER = { "showZoneTriggers", "showFishingSplash", "showLfgPop", "showBackground", "showCharacter", "showEmoteSounds", "showOutput", "showVoiceMode" },
             session = {
                 baselineVolumes = {},
                 baselineMutes = {},
@@ -41,13 +40,26 @@ describe("Schema V5 to V6 Migration", function()
             UpdateMiniMapButtonVisibility = function() end
         }
 
-        -- Mock a V5 Database
+        -- Mock a V6 Database
         _G.VolumeSlidersMMDB = {
-            schemaVersion = 5,
-            automation = {
-                activeManualPresets = {}
+            schemaVersion = 6,
+            toggles = {
+                showZoneTriggers = true,
+                showFishingSplash = true,
+                showLfgPop = true,
+                showBackground = true,
+                showCharacter = true,
+                showOutput = true,
+                showVoiceMode = true
+                -- showEmoteSounds is MISSING
             },
-            minimap = {}
+            layout = {
+                footerOrder = {
+                    "showZoneTriggers", "showFishingSplash", "showLfgPop", "showBackground", "showCharacter", "showOutput", "showVoiceMode"
+                }
+            },
+            minimap = {}, -- Added to prevent Init.lua crash at line 401
+            automation = {} -- Preventive
         }
 
         -- Stub out create frame to catch the Init event script
@@ -67,24 +79,17 @@ describe("Schema V5 to V6 Migration", function()
         _G.CreateFrame = realCreateFrame
     end)
 
-    it("should initialize enableDeviceVolumes and stamp version 6", function()
+    it("should initialize showEmoteSounds and inject it into footerOrder", function()
         local db = _G.VolumeSlidersMMDB
 
         -- Logic is executed during PLAYER_LOGIN
         initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
 
         assert.are.equal(7, db.schemaVersion)
-        assert.is_true(db.automation.enableDeviceVolumes)
-    end)
-
-    it("should not overwrite enableDeviceVolumes if already present", function()
-        local db = _G.VolumeSlidersMMDB
-        -- Pre-seed with false (user manually set it before login somehow, or testing idempotency)
-        db.automation.enableDeviceVolumes = false
+        assert.is_true(db.toggles.showEmoteSounds)
         
-        initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
-
-        assert.are.equal(7, db.schemaVersion)
-        assert.is_false(db.automation.enableDeviceVolumes)
+        -- Check if it was injected at index 6 (before showOutput)
+        assert.are.equal("showEmoteSounds", db.layout.footerOrder[6])
+        assert.are.equal(8, #db.layout.footerOrder)
     end)
 end)

--- a/spec/Migration_spec.lua
+++ b/spec/Migration_spec.lua
@@ -113,7 +113,7 @@ describe("V1 to V2 Database Migration", function()
         local db = _G.VolumeSlidersMMDB
 
         -- Assert Version Label
-        assert.are.equal(6, db.schemaVersion)
+        assert.are.equal(7, db.schemaVersion)
 
         -- Assert transient keys are completely purged
         assert.is_nil(db.originalVolumes)


### PR DESCRIPTION
## v3.7.0 — 2026-04-21

### Added
- **WoW Patch 12.0.5 Support**: Updated to maintain compatibility with the latest World of Warcraft patch (Interface: 120001, 120005).
- **Emote Sounds Toggle**: Added a new "Emote Sounds" checkbox to the main popup footer, allowing users to quickly toggle character emote audio (like /laugh or /cry) without opening Blizzard's settings. 
- **Enriched Automation Tooltips**: Overhauled tooltips for Zone Triggers, Fishing Boost, and LFG Pop Boost to clarify that these automations affect the **Sound Effects (SFX)** channel.
- **Settings Page Visuals**: Changed the background of all configuration pages from semi-transparent grey to **solid black** for less visual noise.

### Fixed
- **Footer Reordering Persistence**: Fixed a bug where reordering footer elements in the Window Customization settings failed to persist in the main UI until a reload. Direct structural changes now trigger immediate layout recalculations.

Closes #15
Closes #24