### PR TITLE
Release v3.8.1: repair sparse footerOrder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# Changelog (v3.8.0)
+# Changelog (v3.8.1-beta1)
+
+## v3.8.1-beta1 — 2026-04-29
+
+### Fixed
+- **Footer Elements Missing**: Fixed an issue where footer controls (like Output Selector and automation toggles) could disappear in the main window after upgrading. The addon now automatically repairs invalid footer ordering data on login so the footer and its settings list return without needing to reset your SavedVariables.
 
 ## v3.8.0 — 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Changelog (v3.8.1-beta1)
+# Changelog (v3.8.1)
 
-## v3.8.1-beta1 — 2026-04-29
+## v3.8.1 — 2026-04-29
 
 ### Fixed
 - **Footer Elements Missing**: Fixed an issue where footer controls (like Output Selector and automation toggles) could disappear in the main window after upgrading. The addon now automatically repairs invalid footer ordering data on login so the footer and its settings list return without needing to reset your SavedVariables.

--- a/VolumeSliders/Init.lua
+++ b/VolumeSliders/Init.lua
@@ -17,8 +17,12 @@ local _, VS = ...
 -- Localized Globals
 -------------------------------------------------------------------------------
 local ipairs    = ipairs
+local pairs     = pairs
 local tonumber  = tonumber
+local type      = type
 local GetCVar   = GetCVar
+local table_insert = table.insert
+local table_sort   = table.sort
 
 -----------------------------------------
 -- Addon Initialization (PLAYER_LOGIN)
@@ -59,6 +63,92 @@ local function MergeTable(target, source)
             target[k] = v
         end
     end
+end
+
+-------------------------------------------------------------------------------
+-- CopyDefaultFooterOrder
+--
+-- Returns a fresh contiguous array copy of `VS.DEFAULT_FOOTER_ORDER`.
+-- Used when migrations or normalization must replace a sparse or invalid list.
+--
+-- @return table
+-------------------------------------------------------------------------------
+local function CopyDefaultFooterOrder()
+    local out = {}
+    for i = 1, #VS.DEFAULT_FOOTER_ORDER do
+        out[i] = VS.DEFAULT_FOOTER_ORDER[i]
+    end
+    return out
+end
+
+-------------------------------------------------------------------------------
+-- NormalizeFooterOrder
+--
+-- Repairs `db.layout.footerOrder` after login: sparse tables, gaps before
+-- later indices, or unknown keys break `ipairs` consumers (`UpdateFooterLayout`,
+-- settings Footer Elements list). This function enforces a contiguous array of
+-- valid canonical keys, preserving a fully valid user order when possible.
+--
+-- @param db table The VolumeSlidersMMDB global table.
+-------------------------------------------------------------------------------
+local function NormalizeFooterOrder(db)
+    if not db or not db.layout then return end
+    local order = db.layout.footerOrder
+    if type(order) ~= "table" then return end
+
+    local valid = {}
+    for _, k in ipairs(VS.DEFAULT_FOOTER_ORDER) do
+        valid[k] = true
+    end
+
+    local ipairsCount = 0
+    for _ in ipairs(order) do
+        ipairsCount = ipairsCount + 1
+    end
+
+    local numericKeys = {}
+    for k, v in pairs(order) do
+        if type(k) == "number" and type(v) == "string" and valid[v] then
+            table_insert(numericKeys, k)
+        end
+    end
+    table_sort(numericKeys)
+    local maxIdx = numericKeys[#numericKeys] or 0
+
+    -- Sparse (e.g. only [6] set) or empty: `ipairs` cannot traverse; canonicalize.
+    if ipairsCount == 0 then
+        db.layout.footerOrder = CopyDefaultFooterOrder()
+        return
+    end
+
+    -- Holes before a later index (e.g. keys 1..4 and 6 set, 5 missing): ipairs truncates.
+    if maxIdx > ipairsCount then
+        db.layout.footerOrder = CopyDefaultFooterOrder()
+        return
+    end
+
+    local compact = {}
+    local seen = {}
+    for _, k in ipairs(order) do
+        if type(k) == "string" and valid[k] and not seen[k] then
+            seen[k] = true
+            table_insert(compact, k)
+        end
+    end
+
+    if #compact == 0 then
+        db.layout.footerOrder = CopyDefaultFooterOrder()
+        return
+    end
+
+    for _, k in ipairs(VS.DEFAULT_FOOTER_ORDER) do
+        if not seen[k] then
+            seen[k] = true
+            table_insert(compact, k)
+        end
+    end
+
+    db.layout.footerOrder = compact
 end
 
 -------------------------------------------------------------------------------
@@ -357,18 +447,34 @@ local function Migrate_V6_to_V7(db)
     if db.schemaVersion and db.schemaVersion >= 7 then return end
 
     db.layout = db.layout or {}
-    db.layout.footerOrder = db.layout.footerOrder or {}
+    if db.layout.footerOrder == nil then
+        db.layout.footerOrder = {}
+    end
+    local fo = db.layout.footerOrder
 
-    -- Inject "showEmoteSounds" if missing
+    -- Inject "showEmoteSounds" if missing. Avoid `table.insert(t, 6, ...)` on empty or short
+    -- lists: Lua leaves a gap so `ipairs` yields no rows (sparse `footerOrder` bug).
+    local contiguous = 0
+    for _ in ipairs(fo) do
+        contiguous = contiguous + 1
+    end
+
     local found = false
-    for _, key in ipairs(db.layout.footerOrder) do
+    for _, key in ipairs(fo) do
         if key == "showEmoteSounds" then
             found = true
             break
         end
     end
+
     if not found then
-        table.insert(db.layout.footerOrder, 6, "showEmoteSounds")
+        if contiguous == 0 then
+            db.layout.footerOrder = CopyDefaultFooterOrder()
+        elseif contiguous >= 5 then
+            table_insert(fo, 6, "showEmoteSounds")
+        else
+            table_insert(fo, "showEmoteSounds")
+        end
     end
 
     db.schemaVersion = 7
@@ -412,6 +518,9 @@ initFrame:SetScript("OnEvent", function(self, event)
 
     -- Merge structural defaults safely
     MergeTable(db, VS.DEFAULT_DB)
+
+    -- Repair sparse/gapped `footerOrder` (V7 migration edge cases and legacy bad data).
+    NormalizeFooterOrder(db)
 
     -- Initialize Unified State Stack Baseline
     -- We capture the user's current volume levels as the "baseline" upon which

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -2,7 +2,7 @@
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels
-## Version: 3.8.0
+## Version: 3.8.1-beta1
 ## SavedVariables: VolumeSlidersMMDB
 ## SavedVariablesPerCharacter:
 ## OptionalDeps:

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -2,7 +2,7 @@
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels
-## Version: 3.8.1-beta1
+## Version: 3.8.1
 ## SavedVariables: VolumeSlidersMMDB
 ## SavedVariablesPerCharacter:
 ## OptionalDeps:

--- a/spec/MergeTable_spec.lua
+++ b/spec/MergeTable_spec.lua
@@ -115,4 +115,32 @@ describe("MergeTable bootstrap behavior", function()
         assert.are.equal(1, bg.b)
         assert.are.equal(0.95, bg.a)
     end)
+
+    it("repairs sparse schema-7 footerOrder so ipairs sees all canonical keys", function()
+        bootstrapWith({
+            schemaVersion = 7,
+            appearance = { bgColor = { r = 0.1, g = 0.1, b = 0.1 } },
+            layout = {
+                sliderOrder = { "Sound_MasterVolume" },
+                footerOrder = { [6] = "showEmoteSounds" },
+                mouseActions = { sliders = {}, scrollWheel = {} },
+            },
+            toggles = {},
+            channels = {},
+            minimap = { minimalistMinimap = true, mouseActions = {}, minimapTooltipOrder = {} },
+            hardware = {},
+            automation = { persistedBaseline = {}, lastAppliedState = {}, presets = {}, activeManualPresets = {} },
+            voice = {},
+        })
+
+        local fo = _G.VolumeSlidersMMDB.layout.footerOrder
+        assert.are.equal(8, #fo)
+        assert.are.equal("showZoneTriggers", fo[1])
+        assert.are.equal("showEmoteSounds", fo[6])
+        local n = 0
+        for _ in ipairs(fo) do
+            n = n + 1
+        end
+        assert.are.equal(8, n)
+    end)
 end)

--- a/spec/MigrationV5_spec.lua
+++ b/spec/MigrationV5_spec.lua
@@ -22,6 +22,16 @@ describe("Schema V4 to V5 Migration", function()
         VS = {
             DEFAULT_CVAR_ORDER = { "Sound_MasterVolume" },
             CHANNEL_MUTE_CVAR = { ["Sound_MasterVolume"] = "Sound_EnableAllSound" },
+            DEFAULT_FOOTER_ORDER = {
+                "showZoneTriggers",
+                "showFishingSplash",
+                "showLfgPop",
+                "showCharacter",
+                "showBackground",
+                "showEmoteSounds",
+                "showOutput",
+                "showVoiceMode",
+            },
             DEFAULT_DB = {
                 schemaVersion = 5,
                 automation = { activeManualPresets = {} },

--- a/spec/MigrationV6_spec.lua
+++ b/spec/MigrationV6_spec.lua
@@ -21,6 +21,16 @@ describe("Schema V5 to V6 Migration", function()
         VS = {
             DEFAULT_CVAR_ORDER = { "Sound_MasterVolume" },
             CHANNEL_MUTE_CVAR = { ["Sound_MasterVolume"] = "Sound_EnableAllSound" },
+            DEFAULT_FOOTER_ORDER = {
+                "showZoneTriggers",
+                "showFishingSplash",
+                "showLfgPop",
+                "showCharacter",
+                "showBackground",
+                "showEmoteSounds",
+                "showOutput",
+                "showVoiceMode",
+            },
             DEFAULT_DB = {
                 schemaVersion = 7,
                 automation = {

--- a/spec/MigrationV7_spec.lua
+++ b/spec/MigrationV7_spec.lua
@@ -93,3 +93,185 @@ describe("Schema V6 to V7 Migration", function()
         assert.are.equal(8, #db.layout.footerOrder)
     end)
 end)
+
+describe("Schema V6 to V7 Migration (empty footerOrder)", function()
+    local VS
+    local initFrameScript
+
+    before_each(function()
+        _G.C_VoiceChat = {
+            GetOutputVolume = function() return 100 end,
+            GetMasterVolumeScale = function() return 1 end,
+            GetInputVolume = function() return 100 end,
+            GetVADSensitivity = function() return 0 end
+        }
+        _G.GetCVar = function() return "1" end
+        _G.SetCVar = function() end
+        _G.C_AddOns = { IsAddOnLoaded = function() return false end }
+
+        VS = {
+            DEFAULT_CVAR_ORDER = { "Sound_MasterVolume" },
+            CHANNEL_MUTE_CVAR = { ["Sound_MasterVolume"] = "Sound_EnableAllSound" },
+            DEFAULT_DB = {
+                schemaVersion = 7,
+                toggles = { showEmoteSounds = false },
+                layout = {
+                    footerOrder = {
+                        "showZoneTriggers", "showFishingSplash", "showLfgPop", "showBackground",
+                        "showCharacter", "showEmoteSounds", "showOutput", "showVoiceMode"
+                    }
+                }
+            },
+            DEFAULT_FOOTER_ORDER = {
+                "showZoneTriggers", "showFishingSplash", "showLfgPop", "showBackground",
+                "showCharacter", "showEmoteSounds", "showOutput", "showVoiceMode"
+            },
+            session = {
+                baselineVolumes = {},
+                baselineMutes = {},
+                activeRegistry = { manual = {} },
+                manualActivationTimes = {}
+            },
+            LDBIcon = { Register = function() end, IsRegistered = function() return false end },
+            InitializeSettings = function() end,
+            UpdateMiniMapButtonVisibility = function() end
+        }
+
+        _G.VolumeSlidersMMDB = {
+            schemaVersion = 6,
+            toggles = {
+                showZoneTriggers = true,
+                showFishingSplash = true,
+                showLfgPop = true,
+                showBackground = true,
+                showCharacter = true,
+                showOutput = true,
+                showVoiceMode = true
+            },
+            layout = {
+                footerOrder = {}
+            },
+            minimap = {},
+            automation = {}
+        }
+
+        local realCreateFrame = _G.CreateFrame
+        _G.CreateFrame = function(frameType, name, parent, template)
+            return {
+                RegisterEvent = function() end,
+                UnregisterEvent = function() end,
+                SetScript = function(self, evt, handler)
+                    if evt == "OnEvent" then initFrameScript = handler end
+                end
+            }
+        end
+
+        assert(loadfile("VolumeSliders/Init.lua"))("VolumeSliders", VS)
+        _G.CreateFrame = realCreateFrame
+    end)
+
+    it("replaces empty footerOrder with a full default array (no sparse insert)", function()
+        local db = _G.VolumeSlidersMMDB
+        initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
+
+        assert.are.equal(7, db.schemaVersion)
+        assert.are.equal(8, #db.layout.footerOrder)
+        assert.are.equal("showZoneTriggers", db.layout.footerOrder[1])
+        assert.are.equal("showEmoteSounds", db.layout.footerOrder[6])
+    end)
+end)
+
+describe("Schema V6 to V7 Migration (short footerOrder)", function()
+    local VS
+    local initFrameScript
+
+    before_each(function()
+        _G.C_VoiceChat = {
+            GetOutputVolume = function() return 100 end,
+            GetMasterVolumeScale = function() return 1 end,
+            GetInputVolume = function() return 100 end,
+            GetVADSensitivity = function() return 0 end
+        }
+        _G.GetCVar = function() return "1" end
+        _G.SetCVar = function() end
+        _G.C_AddOns = { IsAddOnLoaded = function() return false end }
+
+        VS = {
+            DEFAULT_CVAR_ORDER = { "Sound_MasterVolume" },
+            CHANNEL_MUTE_CVAR = { ["Sound_MasterVolume"] = "Sound_EnableAllSound" },
+            DEFAULT_DB = {
+                schemaVersion = 7,
+                toggles = { showEmoteSounds = false },
+                layout = {
+                    footerOrder = {
+                        "showZoneTriggers", "showFishingSplash", "showLfgPop", "showBackground",
+                        "showCharacter", "showEmoteSounds", "showOutput", "showVoiceMode"
+                    }
+                }
+            },
+            DEFAULT_FOOTER_ORDER = {
+                "showZoneTriggers", "showFishingSplash", "showLfgPop", "showBackground",
+                "showCharacter", "showEmoteSounds", "showOutput", "showVoiceMode"
+            },
+            session = {
+                baselineVolumes = {},
+                baselineMutes = {},
+                activeRegistry = { manual = {} },
+                manualActivationTimes = {}
+            },
+            LDBIcon = { Register = function() end, IsRegistered = function() return false end },
+            InitializeSettings = function() end,
+            UpdateMiniMapButtonVisibility = function() end
+        }
+
+        _G.VolumeSlidersMMDB = {
+            schemaVersion = 6,
+            toggles = {
+                showZoneTriggers = true,
+                showFishingSplash = true,
+                showLfgPop = true,
+                showBackground = true,
+                showCharacter = true,
+                showOutput = true,
+                showVoiceMode = true
+            },
+            layout = {
+                footerOrder = {
+                    "showZoneTriggers",
+                    "showFishingSplash",
+                    "showLfgPop",
+                    "showCharacter"
+                }
+            },
+            minimap = {},
+            automation = {}
+        }
+
+        local realCreateFrame = _G.CreateFrame
+        _G.CreateFrame = function(frameType, name, parent, template)
+            return {
+                RegisterEvent = function() end,
+                UnregisterEvent = function() end,
+                SetScript = function(self, evt, handler)
+                    if evt == "OnEvent" then initFrameScript = handler end
+                end
+            }
+        end
+
+        assert(loadfile("VolumeSliders/Init.lua"))("VolumeSliders", VS)
+        _G.CreateFrame = realCreateFrame
+    end)
+
+    it("appends showEmoteSounds without creating a gap when fewer than 5 entries exist", function()
+        local db = _G.VolumeSlidersMMDB
+        initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
+
+        assert.are.equal(7, db.schemaVersion)
+        assert.are.equal("showEmoteSounds", db.layout.footerOrder[5])
+        local n = 0
+        for _ in ipairs(db.layout.footerOrder) do
+            n = n + 1
+        end
+        assert.are.equal(8, n)
+    end)
+end)


### PR DESCRIPTION
## Summary
- Fixes a migration edge case that could leave `layout.footerOrder` sparse/gapped, causing the popup footer and the Window Settings footer list to appear empty.
- Adds a login-time repair step to normalize malformed footer ordering data without requiring a schema bump or SavedVariables reset.
- Adds regression tests for empty/short V6 `footerOrder` and sparse schema-7 `footerOrder`.

Closes #38

## Test plan
- [x] luacheck VolumeSliders
- [x] busted (97/97)
- [x] In-game spot check: Window Settings → Footer Elements list populated; popup footer controls visible when enabled