### PR TITLE
Fix stale volume restore on mute toggles

### DIFF
--- a/VolumeSliders/Core.lua
+++ b/VolumeSliders/Core.lua
@@ -524,7 +524,11 @@ function VS:SyncBaseline(channel, value, isVoiceMuteToggle)
         if anyActive then break end
     end
 
-    if anyActive and not isMuteCVar and not isVoiceMuteToggle then
+    if not anyActive then
+        return
+    end
+
+    if not isMuteCVar and not isVoiceMuteToggle then
         sess.manualOverrides[targetChannel] = true
     end
 

--- a/VolumeSliders/SliderWidgets.lua
+++ b/VolumeSliders/SliderWidgets.lua
@@ -341,6 +341,9 @@ function VS:CreateVerticalSlider(parent, name, label, cvar, muteCvar, minVal, ma
             end
         end
 
+        -- Unified State Sync: Keep the baseline informed of manual user adjustments.
+        VS:SyncBaseline(cvar, val)
+
         if VS.PlaySampleSound then
             VS:PlaySampleSound(cvar, val)
         end

--- a/spec/Presets_spec.lua
+++ b/spec/Presets_spec.lua
@@ -112,6 +112,18 @@ describe("Registry-based Preset Logic (Unified State Stack)", function()
         assert.are.equal("0.7", _G.cvarStorage["Sound_MasterVolume"])
     end)
 
+    it("does not rewrite unrelated channels when syncing mute state with no active presets", function()
+        VS.session.baselineVolumes["Sound_MasterVolume"] = 0.4
+        VS.session.baselineMutes["Sound_MusicVolume"] = "0"
+        _G.cvarStorage["Sound_MasterVolume"] = "0.9"
+        _G.cvarStorage["Sound_EnableMusic"] = "0"
+
+        VS:SyncBaseline("Sound_EnableMusic", "1")
+
+        assert.are.equal("0.9", _G.cvarStorage["Sound_MasterVolume"])
+        assert.are.equal("1", VS.session.baselineMutes["Sound_MusicVolume"])
+    end)
+
     it("filters CVAR_UPDATE to prevent infinite loops", function()
         -- Simulate Blizzard UI changing a volume
         VS.session.isSettingInternal = false

--- a/spec/SliderWidgets_spec.lua
+++ b/spec/SliderWidgets_spec.lua
@@ -35,4 +35,14 @@ describe("SliderWidgets Factory Module", function()
         local onWheel = slider:GetScript("OnMouseWheel")
         assert.is_function(onWheel)
     end)
+
+    it("syncs the baseline when a standard slider changes", function()
+        local slider = VS:CreateVerticalSlider(_G.UIParent, "SyncSlider", "Sync", "Sound_MasterVolume", "Sound_EnableAllSound", 0, 1, 0.01)
+        local onValueChanged = slider:GetScript("OnValueChanged")
+
+        onValueChanged(slider, 0.25)
+
+        assert.are.equal("0.75", _G.GetCVar("Sound_MasterVolume"))
+        assert.are.equal(0.75, VS.session.baselineVolumes["Sound_MasterVolume"])
+    end)
 end)


### PR DESCRIPTION
## Summary
- Fixes stale baseline reevaluation so mute/unmute clicks cannot restore unrelated channel volumes when no presets are active.
- Syncs standard slider baseline state immediately on manual slider changes.
- Adds regression coverage for issue #40 and slider baseline synchronization.

## Test plan
- [x] `luacheck VolumeSliders spec`
- [x] `busted . --verbose`
- [x] In-game smoke test: no active presets, change one channel volume, mute/unmute another channel, confirm the changed channel does not revert.

Fixes #40
