### PR TITLE
Prepare v3.9.1 release workflow

### DIFF
--- a/.agents/skills/wow-release/SKILL.md
+++ b/.agents/skills/wow-release/SKILL.md
@@ -9,16 +9,18 @@ compatibility: Requires git, GitHub access, gh or GitHub MCP, and repository val
 ## Instructions
 
 1. Read `AGENTS.md`, `docs/AGENT_WORKFLOW.md`, `docs/CI_AND_RELEASE.md`, and the current diff.
-2. Confirm the user explicitly asked for release preparation.
+2. Treat normal user-facing bug fixes and features as release preparation unless the user explicitly says not to ship the change yet.
 3. Review completed work, linked issues, validation status, and release scope.
 4. Draft release notes using `references/Release_Notes_Template.md`.
-5. Synchronize required version and changelog files.
+5. Synchronize required version and changelog files before opening the PR.
 6. Run required validation before committing, pushing, or opening a PR when code changed.
-7. Use an ignored markdown file plus `--body-file` for GitHub CLI PR bodies.
-8. Open a PR targeting `master` and wait for CI.
-9. Instruct the human user to manually squash and merge on GitHub.
-10. Stop until the user confirms the PR was merged.
-11. Ask explicit permission before creating or pushing any release tag.
+7. Confirm the branch starts from `origin/master` and `git log origin/master...HEAD` contains only intended commits.
+8. Use an ignored markdown file plus `--body-file` for GitHub CLI PR bodies.
+9. Open a PR targeting `master` and wait for CI.
+10. Instruct the human user to manually squash and merge on GitHub.
+11. Stop until the user confirms the PR was merged.
+12. After merge confirmation, fetch/prune, fast-forward local `master`, verify the release version on `master`, and clean up the local dev branch.
+13. Ask explicit permission before creating or pushing the annotated release tag for the exact version.
 
 ## Hard Constraints
 

--- a/.agents/workflows/bugfix-cycle.md
+++ b/.agents/workflows/bugfix-cycle.md
@@ -17,3 +17,4 @@ Use this workflow when the user reports broken behavior, screenshots, errors, fa
 5. Act as `@validator` and run `wow-validation`.
 6. If validation fails, repeat the debugging and validation loop until clean or blocked.
 7. Update comments or docs when the bug reveals a stable contract or non-obvious invariant.
+8. For normal user-facing fixes, continue into `release-pr` so the fix includes version and changelog updates unless the user explicitly says not to ship it yet.

--- a/.agents/workflows/release-pr.md
+++ b/.agents/workflows/release-pr.md
@@ -8,15 +8,17 @@ description: Prepare a PR-based release while preserving human merge and tag gat
 
 # Release PR Workflow
 
-Use this workflow only when the user explicitly asks to prepare a release.
+Use this workflow when the user asks to prepare a release, or when a normal user-facing bug fix or feature is ready for PR unless the user explicitly says not to ship it yet.
 
 1. Act as `@release-manager` and run the `wow-release` skill.
-2. Review the current branch, diff, issue links, changelog needs, and validation status.
-3. Synchronize required version and changelog files according to `docs/CI_AND_RELEASE.md`.
-4. Run required validation for code changes before committing or pushing.
-5. Create a PR body in an ignored local markdown file and use `gh pr create --body-file` if using the GitHub CLI.
-6. Push the dev branch and open a PR targeting `master`.
-7. Wait for CI to pass.
-8. Instruct the human user to manually squash and merge the PR on GitHub.
-9. Stop until the user confirms the PR has been merged.
-10. After user confirmation, pull `master`, verify `HEAD`, and ask explicit permission before creating any release tag.
+2. Ensure the work is on a clean `dev/*` branch based on current `origin/master`.
+3. Review the current branch, diff, issue links, changelog needs, and validation status.
+4. Synchronize required version and changelog files according to `docs/CI_AND_RELEASE.md`.
+5. Run required validation for code changes before committing or pushing.
+6. Verify `git log origin/master...HEAD` contains only intended commits.
+7. Create a PR body in an ignored local markdown file and use `gh pr create --body-file` if using the GitHub CLI.
+8. Push the dev branch and open a PR targeting `master`.
+9. Wait for CI to pass.
+10. Instruct the human user to manually squash and merge the PR on GitHub.
+11. Stop until the user confirms the PR has been merged.
+12. After user confirmation, fetch/prune, fast-forward local `master`, verify `HEAD` and release metadata, clean up the local dev branch, and ask explicit permission before creating any annotated release tag.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ The release package is built from `VolumeSliders/`; docs and AI configuration ar
 ## Development Rules
 
 - Work on a `dev/*` branch for repository modifications. Do not commit directly to `master`.
+- For PR-bound work, start from current `origin/master` unless the user explicitly asks for a stacked branch.
 - Keep changes scoped to the user's request and the established module boundaries.
 - Preserve existing comments, LDoc, taint notes, and security breadcrumbs unless they are stale. Update misleading comments when touching related logic.
 - New Lua functions must use LDoc comments when they introduce non-obvious behavior or public module surface.
@@ -89,9 +90,10 @@ Documentation-only changes do not require the Lua test suite unless they alter d
 
 - Assume Windows paths and PowerShell unless a tool explicitly provides another shell.
 - Run git commands one at a time and inspect their output before the next git action.
+- Before opening a PR, verify `git log origin/master...HEAD` contains only intended commits.
 - For `gh pr create`, `gh issue comment`, or other long GitHub CLI bodies, write the body to an ignored markdown file first and use `--body-file`.
 - Do not merge pull requests. Only the human user may merge PRs.
-- Do not create or push release tags without explicit user permission for that tag.
+- After the human confirms a squash merge, sync local `master`, clean up the local dev branch, and ask explicit permission before creating or pushing the annotated release tag for the exact version.
 
 ## Documentation Style
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# Changelog (v3.9.0)
+# Changelog (v3.9.1)
+
+## v3.9.1 — 2026-05-12
+
+### Fixed
+- **Mute Toggle Volume Restore**: Fixed an issue where unmuting one channel could unexpectedly restore a different channel to an older volume when no presets were active.
 
 ## v3.9.0 — 2026-05-07
 

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -2,7 +2,7 @@
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels
-## Version: 3.9.0
+## Version: 3.9.1
 ## SavedVariables: VolumeSlidersMMDB
 ## SavedVariablesPerCharacter:
 ## OptionalDeps:

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -39,6 +39,7 @@ If CI or workflow files change, review `docs/CI_AND_RELEASE.md` and ensure the d
 
 - Identify affected modules and whether the change touches Lua, XML, docs, tests, CI, saved variables, or release metadata.
 - Create or use a `dev/*` branch for repository modifications.
+- For PR-bound work, start from current `origin/master` unless the user explicitly asks to stack on another branch.
 - Do not write implementation code before the boundaries are clear.
 - For large or risky work, produce an architecture artifact in an ignored artifact directory.
 
@@ -82,14 +83,16 @@ If CI or workflow files change, review `docs/CI_AND_RELEASE.md` and ensure the d
 ### Release
 
 - Follow `docs/CI_AND_RELEASE.md` and the tracked Antigravity release workflow.
+- Treat normal user-facing bug fixes and features as release PRs for this one-maintainer addon unless the user explicitly says not to ship the change yet.
 - Version bumping must keep these files synchronized:
   - `VolumeSliders/VolumeSliders.toc`
   - `CHANGELOG.md`
   - `local_dev_assets/dev_changelog.md` when present and relevant
   - `README.md` only when user-facing feature status changes
+- Before opening a PR, verify the branch contains only intended commits with `git log origin/master...HEAD`.
 - All merges into `master` must go through a GitHub PR.
 - The agent must not merge PRs.
-- The agent must not create or push release tags without explicit permission for that tag.
+- After the human confirms a squash merge, fetch/prune, fast-forward local `master`, delete the local dev branch, verify the release version on `master`, and ask explicit permission before creating or pushing the annotated release tag for that exact version.
 
 ## Saved Variable Rules
 

--- a/docs/CI_AND_RELEASE.md
+++ b/docs/CI_AND_RELEASE.md
@@ -34,6 +34,39 @@ Release packaging uses `BigWigsMods/packager@v2`.
 
 The release workflow trims `CHANGELOG.md` down to the latest `## v...` section before packaging so release notes contain only the newest version entry.
 
+## Release Policy
+
+Volume Sliders is a small one-maintainer addon. In normal maintenance, every user-facing bug fix or feature PR is also a release PR unless the user explicitly says it should not ship yet.
+
+Before opening a release PR:
+
+1. Start from a clean `dev/*` branch based on current `origin/master`.
+2. Apply the code, docs, and test changes.
+3. Choose the next semantic version for the scope:
+   - Patch (`x.y.Z`) for bug fixes and small documentation/release workflow corrections.
+   - Minor (`x.Y.0`) for user-facing features or notable behavior changes.
+   - Major (`X.0.0`) only for breaking saved-variable or compatibility changes.
+4. Synchronize release metadata:
+   - `VolumeSliders/VolumeSliders.toc` `## Version:`
+   - `CHANGELOG.md` title and newest release section
+   - `local_dev_assets/dev_changelog.md` when present and relevant
+   - `README.md` only when user-facing feature status or install guidance changes
+5. Run local validation:
+   - `luacheck VolumeSliders spec`
+   - `busted . --verbose`
+6. Verify the PR will contain only intended commits with `git log origin/master...HEAD`.
+7. Open a PR targeting `master` and include the validation results, manual in-game testing when applicable, and linked issue closure text.
+
+The human maintainer performs the squash merge on GitHub.
+
+After the maintainer confirms the merge:
+
+1. Run `git fetch origin --prune`.
+2. Switch to `master` and run `git pull --ff-only`.
+3. Verify `HEAD`, `CHANGELOG.md`, and `VolumeSliders/VolumeSliders.toc` match the intended release version.
+4. Delete the merged local `dev/*` branch. Squash merges usually require `git branch -D` because the exact branch commit is not an ancestor of `master`.
+5. Ask explicit permission before creating and pushing the annotated release tag for the exact version, for example `v3.9.1`.
+
 ## Local Equivalents
 
 Run these before opening a PR:


### PR DESCRIPTION
## Summary
- Bumps the addon release metadata to v3.9.1 for the issue #40 bugfix release.
- Documents that normal user-facing bug fixes and features for this one-maintainer addon should be treated as release PRs unless explicitly held back.
- Adds branch hygiene, post-squash cleanup, and annotated tag permission gates to the AI workflow docs and release skill/workflow.

## Test plan
- [x] `luacheck VolumeSliders spec`
- [x] `busted . --verbose`
- [x] Verified `git log origin/master...HEAD` contains only the release workflow/version commit.
