### PR TITLE
Release v3.10.0: volume display formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# Changelog (v3.9.1)
+# Changelog (v3.10.0)
+
+## v3.10.0 — 2026-05-12
+
+### Added
+- **Volume Display Formats**: Added a new Slider Customization option to display volume values as percentages, decimals, or decibels across the popup window, minimap broker text, minimap tooltip, and preset editor sliders.
 
 ## v3.9.1 — 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Quick-access vertical volume sliders for every WoW sound channel, right from you
 ### Window & Appearance
 - **2D resizable window** — drag edges or corners; sliders and footer elements reflow automatically.
 - **Custom backgrounds** — adjust window color and opacity via the native Blizzard color picker.
+- **Volume display formats** — show values as percentages, decimals, or decibels across sliders and minimap displays.
 - **Lock, persist, or auto-close** — pin the window in place, keep it open across sessions, or let it dismiss on click-away.
 
 ### Ecosystem

--- a/VolumeSliders/Appearance.lua
+++ b/VolumeSliders/Appearance.lua
@@ -15,7 +15,6 @@ local _, VS = ...
 -------------------------------------------------------------------------------
 -- Localized Globals
 -------------------------------------------------------------------------------
-local math_floor = math.floor
 local math_max   = math.max
 local pairs      = pairs
 local ipairs     = ipairs
@@ -588,6 +587,22 @@ function VS:UpdateAppearance()
     -- Only flag the layout as clean if we actually populated sliders this pass
     if VS.sliders and next(VS.sliders) ~= nil then
         VS.session.layoutDirty = false
+    end
+end
+
+-------------------------------------------------------------------------------
+--- Refresh visible slider value labels after display-format changes.
+function VS:RefreshSliderValueTexts()
+    if VS.sliders then
+        for _, slider in pairs(VS.sliders) do
+            if slider.RefreshValue then
+                slider:RefreshValue()
+            end
+        end
+    end
+
+    if VS.previewSlider and VS.previewSlider.RefreshValue then
+        VS.previewSlider:RefreshValue()
     end
 end
 

--- a/VolumeSliders/Core.lua
+++ b/VolumeSliders/Core.lua
@@ -24,8 +24,10 @@ local math_floor = math.floor
 local math_max   = math.max
 local math_min   = math.min
 local math_ceil  = math.ceil
+local math_log   = math.log
 local tonumber   = tonumber
 local tostring   = tostring
+local string_format = string.format
 local pairs      = pairs
 local ipairs     = ipairs
 local GetCVar    = GetCVar
@@ -197,7 +199,7 @@ VS.DEFAULT_FOOTER_ORDER = {
     "showVoiceMode",
 }
 
--- Database Schema Defaults (SchemaVersion 7)
+-- Database Schema Defaults (SchemaVersion 9)
 -------------------------------------------------------------------------------
 --- @class VolumeSlidersAutomation
 --- @field persistedBaseline table<string, number>
@@ -222,7 +224,7 @@ VS.DEFAULT_FOOTER_ORDER = {
 --- @field voice table
 
 VS.DEFAULT_DB = {
-    schemaVersion = 8,
+    schemaVersion = 9,
     
     appearance = {
         bgColor = { r = 0.05, g = 0.05, b = 0.05, a = 0.95 },
@@ -236,6 +238,7 @@ VS.DEFAULT_DB = {
         windowHeight = VS.DEFAULT_WINDOW_HEIGHT,
         sampleSound = 856,
         sampleSoundMinimap = 856,
+        volumeDisplayFormat = "percentage",
     },
     
     layout = {
@@ -414,12 +417,30 @@ function VS:GetMasterVolume()
     return tonumber(volStr) or 1
 end
 
---- Return a human-readable percentage string for the current master volume.
+--- Return a human-readable string for a normalized volume value.
+-- @param value number Volume level in the range [0, 1].
+-- @return string Example: "75%", "0.75", or "-2.5 dB".
+function VS:FormatVolumeValue(value)
+    local vol = math_max(0, math_min(1, tonumber(value) or 0))
+    local db = VolumeSlidersMMDB
+    local format = db and db.appearance and db.appearance.volumeDisplayFormat or "percentage"
+
+    if format == "decimal" then
+        return string_format("%.2f", vol)
+    elseif format == "decibel" then
+        if vol <= 0 then
+            return "-∞ dB"
+        end
+        return string_format("%.1f dB", 20 * (math_log(vol) / math_log(10)))
+    end
+
+    return tostring(math_floor(vol * 100 + 0.5)) .. "%"
+end
+
+--- Return a human-readable display string for the current master volume.
 -- @return string Example: "75%"
 function VS:GetVolumeText()
-    local vol = self:GetMasterVolume()
-    vol = vol * 100
-    return tostring(math_floor(vol + 0.5)) .. "%"
+    return self:FormatVolumeValue(self:GetMasterVolume())
 end
 
 --- Adjust a volume channel by one increment in the given direction.
@@ -466,7 +487,7 @@ function VS:AdjustVolume(delta, customStep, cvar)
     if VS.sliders and VS.sliders[targetCVar] then
          local sliderVal = 1 - current
          VS.sliders[targetCVar]:SetValue(sliderVal)
-         VS.sliders[targetCVar].valueText:SetText(math_floor(current * 100 + 0.5) .. "%")
+         VS.sliders[targetCVar].valueText:SetText(self:FormatVolumeValue(current))
     end
 
     -- Unified State Sync: Keep the baseline informed of manual user adjustments.
@@ -609,11 +630,11 @@ function VS:StartHardwareRecovery(targetVolume, optionalDeviceName)
             slider:SetValue(1 - target)
             -- Force the text update even if isSwitching is true to ensure
             -- the UI doesn't get stuck at 100% if the engine wins a race.
-            slider.valueText:SetText(math_floor(target * 100 + 0.5) .. "%")
+            slider.valueText:SetText(self:FormatVolumeValue(target))
             slider.isRefreshing = false
         end
         if self.VolumeSlidersObject then
-            self.VolumeSlidersObject.text = (math_floor(target * 100 + 0.5)) .. "%"
+            self.VolumeSlidersObject.text = self:FormatVolumeValue(target)
         end
         if self.UpdateMiniMapVolumeIcon then
             self:UpdateMiniMapVolumeIcon()

--- a/VolumeSliders/Init.lua
+++ b/VolumeSliders/Init.lua
@@ -511,6 +511,24 @@ local function Migrate_V7_to_V8(db)
 end
 
 -------------------------------------------------------------------------------
+-- V8 -> V9 Schema Migration Engine
+--
+-- Adds the `volumeDisplayFormat` property to the `appearance` namespace.
+--
+-- @param db table The VolumeSlidersMMDB global table.
+-------------------------------------------------------------------------------
+local function Migrate_V8_to_V9(db)
+    if db.schemaVersion and db.schemaVersion >= 9 then return end
+
+    db.appearance = db.appearance or {}
+    if db.appearance.volumeDisplayFormat == nil then
+        db.appearance.volumeDisplayFormat = "percentage"
+    end
+
+    db.schemaVersion = 9
+end
+
+-------------------------------------------------------------------------------
 -- Main Event Handler (PLAYER_LOGIN)
 --
 -- Orchestrates the addon bootstrap sequence:
@@ -531,6 +549,7 @@ initFrame:SetScript("OnEvent", function(self, event)
     Migrate_V5_to_V6(db)
     Migrate_V6_to_V7(db)
     Migrate_V7_to_V8(db)
+    Migrate_V8_to_V9(db)
     
     -- Smart Auto-Detection for Minimalist Minimap Icon
     -- We do this BEFORE MergeTable to ensure detection sets the "Smart Default"

--- a/VolumeSliders/MinimapBroker.lua
+++ b/VolumeSliders/MinimapBroker.lua
@@ -16,7 +16,6 @@ local _, VS = ...
 -------------------------------------------------------------------------------
 -- Localized Globals
 -------------------------------------------------------------------------------
-local math_floor = math.floor
 local tonumber   = tonumber
 local pairs      = pairs
 local GetCVar    = GetCVar
@@ -160,7 +159,7 @@ VS.VolumeSlidersObject = VS.LDB:NewDataObject("Volume Sliders", {
                 end
             elseif item.type == "ChannelVolume" and item.channel then
                 local valStr = GetCVar(item.channel) or "0"
-                local val = math_floor((tonumber(valStr) or 0) * 100 + 0.5)
+                local valueText = VS:FormatVolumeValue(tonumber(valStr) or 0)
                 local niceNames = {
                     ["Sound_MasterVolume"] = "Master",
                     ["Sound_SFXVolume"] = "SFX",
@@ -176,7 +175,7 @@ VS.VolumeSlidersObject = VS.LDB:NewDataObject("Volume Sliders", {
                     ["Voice_MicSensitivity"] = "Mic Sensitivity",
                 }
                 local pretty = niceNames[item.channel] or item.channel
-                tooltip:AddLine(string.format("%s: |cffffffff%d%%|r", pretty, val), 1, 0.82, 0)
+                tooltip:AddLine(string.format("%s: |cffffffff%s|r", pretty, valueText), 1, 0.82, 0)
             end
         end
     end,
@@ -229,7 +228,7 @@ end
 -- Tooltip Refresh Helper
 --
 -- Rebuilds the active minimap tooltip if it's currently showing, allowing
--- real-time updates of volume percentages and preset states after actions.
+-- real-time updates of volume displays and preset states after actions.
 -------------------------------------------------------------------------------
 function VS:RefreshMinimapTooltip()
     -- Case 1: Minimalist button using standard GameTooltip
@@ -571,7 +570,7 @@ eventFrame:SetScript("OnEvent", function(self, event, cvarName, value)
         if VS.sliders and VS.sliders["Sound_MasterVolume"] then
              local val = tonumber(value) or 0
              VS.sliders["Sound_MasterVolume"]:SetValue(1 - val)
-             VS.sliders["Sound_MasterVolume"].valueText:SetText(math_floor(val * 100 + 0.5) .. "%")
+             VS.sliders["Sound_MasterVolume"].valueText:SetText(VS:FormatVolumeValue(val))
         end
     end
 end)

--- a/VolumeSliders/Settings_Sliders.lua
+++ b/VolumeSliders/Settings_Sliders.lua
@@ -13,7 +13,6 @@ local addonName, VS = ...
 -- Localized Globals
 -------------------------------------------------------------------------------
 local _G = _G
-local math_floor = math.floor
 local tostring   = tostring
 local ipairs     = ipairs
 
@@ -110,9 +109,36 @@ function VS:CreateSlidersSettingsContents(parentFrame)
     end)
     valueDropdown:GenerateMenu()
 
+    -- Value Display Format Label & Dropdown
+    local formatLabel = categoryFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+    formatLabel:SetPoint("TOPLEFT", valueDropdown, "BOTTOMLEFT", 15, dropdownSpacingOffset)
+    formatLabel:SetText("Value Display Format")
+
+    local function IsFormatSelected(value)
+        return (db.appearance.volumeDisplayFormat or "percentage") == value
+    end
+    local function SetFormatSelected(value)
+        db.appearance.volumeDisplayFormat = value
+        VS:UpdateAppearance()
+        if VS.RefreshSliderValueTexts then VS:RefreshSliderValueTexts() end
+        if VS.VolumeSlidersObject then VS.VolumeSlidersObject.text = VS:GetVolumeText() end
+        if VS.RefreshMinimapTooltip then VS:RefreshMinimapTooltip() end
+    end
+
+    local formatDropdown = CreateFrame("DropdownButton", nil, categoryFrame, "WowStyle1DropdownTemplate")
+    formatDropdown:SetPoint("TOPLEFT", formatLabel, "BOTTOMLEFT", -15, -8)
+    formatDropdown:SetWidth(dropdownWidth)
+    formatDropdown:SetupMenu(function(dropdown, rootDescription)
+        rootDescription:CreateRadio("Percentage (80%)", IsFormatSelected, SetFormatSelected, "percentage")
+        rootDescription:CreateRadio("Decimal (0.80)", IsFormatSelected, SetFormatSelected, "decimal")
+        rootDescription:CreateRadio("Decibel (-1.9 dB)", IsFormatSelected, SetFormatSelected, "decibel")
+    end)
+    formatDropdown:GenerateMenu()
+    VS:AddTooltip(formatDropdown, "Choose how current volume values are displayed in sliders, broker text, and tooltips.")
+
     -- High Color Label & Dropdown
     local highColorLabel = categoryFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
-    highColorLabel:SetPoint("TOPLEFT", valueDropdown, "BOTTOMLEFT", 15, dropdownSpacingOffset)
+    highColorLabel:SetPoint("TOPLEFT", formatDropdown, "BOTTOMLEFT", 15, dropdownSpacingOffset)
     highColorLabel:SetText("High Text Color")
 
     local function IsHighSelected(value)
@@ -287,7 +313,7 @@ function VS:CreateSlidersSettingsContents(parentFrame)
 
     -- Apply tooltips to dropdown labels
     VS:AddTooltip(titleDropdown, "Change the color of the channel titles (e.g. 'Master') to Gold or White.")
-    VS:AddTooltip(valueDropdown, "Change the color of the volume percentage numbers to Gold or White.")
+    VS:AddTooltip(valueDropdown, "Change the color of the displayed volume values to Gold or White.")
     VS:AddTooltip(highDropdown, "Change the color of the '100%' marker to Gold or White.")
     VS:AddTooltip(lowDropdown, "Change the color of the '0%' marker to Gold or White.")
     VS:AddTooltip(soundDropdown, "Select the chime to play when adjusting sliders, or enter a custom SoundKit ID / File Path.")
@@ -355,7 +381,7 @@ function VS:CreateSlidersSettingsContents(parentFrame)
 
     local checkboxes = {
         { name = "Title", var = "showTitle", namespace = "toggles", tooltip = "Show or hide the channel name (e.g., 'Master') above each slider." },
-        { name = "Value (%)", var = "showValue", namespace = "toggles", tooltip = "Show or hide the volume percentage text above each slider." },
+        { name = "Value", var = "showValue", namespace = "toggles", tooltip = "Show or hide the formatted volume value above each slider." },
         { name = "High Label", var = "showHigh", namespace = "toggles", tooltip = "Show or hide the '100%' label at the top of the slider track." },
         { name = "Up Arrow", var = "showUpArrow", namespace = "toggles", tooltip = "Show or hide the button for fine-tuning volume increments." },
         { name = "Slider Track", var = "showSlider", namespace = "toggles", tooltip = "Show or hide the main vertical slider bar and knob." },

--- a/VolumeSliders/SliderWidgets.lua
+++ b/VolumeSliders/SliderWidgets.lua
@@ -32,7 +32,7 @@ local SetCVar    = SetCVar
 --   • Three-piece track (top cap, middle fill, bottom cap) using rotated atlases
 --   • Diamond thumb texture
 --   • Stepper arrow buttons (▲ / ▼) with configurable snap behavior
---   • Labels: title, percentage, High, Low
+--   • Labels: title, formatted value, High, Low
 --   • Mouse wheel handler
 --
 -- DESIGN NOTE: The slider uses "Inverted Value" logic internally.
@@ -211,7 +211,7 @@ local function CreateSliderBase(parent, name, label, tooltipText)
     slider.lowLabel:SetPoint("TOP", slider, "BOTTOM", 0, -26)
     slider.lowLabel:SetText("Low")
 
-    -- Numeric percentage readout above the "High" text.
+    -- Numeric volume readout above the "High" text.
     slider.valueText = slider:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     slider.valueText:SetPoint("BOTTOM", slider.highLabel, "TOP", 0, 10)
     slider.valueText:SetTextColor(NORMAL_FONT_COLOR:GetRGB())
@@ -313,7 +313,7 @@ function VS:CreateVerticalSlider(parent, name, label, cvar, muteCvar, minVal, ma
     ---------------------------------------------------------------------------
     local currentVolume = tonumber(GetCVar(cvar)) or 1
     slider:SetValue(1 - currentVolume)
-    slider.valueText:SetText(math_floor(currentVolume * 100 + 0.5) .. "%")
+    slider.valueText:SetText(VS:FormatVolumeValue(currentVolume))
 
     slider:SetScript("OnValueChanged", function(self, value)
         if self.isRefreshing then return end
@@ -332,7 +332,7 @@ function VS:CreateVerticalSlider(parent, name, label, cvar, muteCvar, minVal, ma
         local val = math_floor(invertedValue * 100 + 0.5) / 100
 
         SetCVar(cvar, val)
-        self.valueText:SetText(math_floor(val * 100 + 0.5) .. "%")
+        self.valueText:SetText(VS:FormatVolumeValue(val))
 
         -- Keep the broker text in sync when the Master slider moves.
         if cvar == "Sound_MasterVolume" then
@@ -399,7 +399,7 @@ function VS:CreateVerticalSlider(parent, name, label, cvar, muteCvar, minVal, ma
         local currentVol = tonumber(GetCVar(cvar)) or 1
         self.isRefreshing = true
         self:SetValue(1 - currentVol)
-        self.valueText:SetText(math_floor(currentVol * 100 + 0.5) .. "%")
+        self.valueText:SetText(VS:FormatVolumeValue(currentVol))
         self.isRefreshing = false
     end
 
@@ -494,7 +494,7 @@ function VS:CreateVoiceSlider(parent, name, label, getterFunc, setterFunc, displ
 
         self.isRefreshing = true
         self:SetValue(1 - currentVol)
-        self.valueText:SetText(math_floor(currentVol * 100 + 0.5) .. "%")
+        self.valueText:SetText(VS:FormatVolumeValue(currentVol))
         self.isRefreshing = false
     end
 
@@ -502,7 +502,7 @@ function VS:CreateVoiceSlider(parent, name, label, getterFunc, setterFunc, displ
         local val = 1 - invertedValue
         val = math_max(0, math_min(1, val))
 
-        self.valueText:SetText(math_floor(val * 100 + 0.5) .. "%")
+        self.valueText:SetText(VS:FormatVolumeValue(val))
 
         if self.isRefreshing then return end
 
@@ -520,7 +520,7 @@ function VS:CreateVoiceSlider(parent, name, label, getterFunc, setterFunc, displ
 
         if not db.voice["MuteState_"..muteKey] then
             setterFunc(rawValue * 100)
-            self.valueText:SetText(math_floor(rawValue * 100 + 0.5) .. "%")
+            self.valueText:SetText(VS:FormatVolumeValue(rawValue))
             
             -- Unified State Sync: Keep the baseline informed of manual user adjustments.
             VS:SyncBaseline(muteKey, rawValue)
@@ -654,7 +654,7 @@ function VS:CreateTriggerSlider(parent, name, label, channelKey, workingTable, m
 
     local currentObjVol = workingTable.volumes[channelKey]
     slider:SetValue(1 - currentObjVol)
-    slider.valueText:SetText(math_floor(currentObjVol * 100 + 0.5) .. "%")
+    slider.valueText:SetText(VS:FormatVolumeValue(currentObjVol))
 
     slider:SetScript("OnValueChanged", function(self, value)
         if self.isRefreshing then return end
@@ -664,7 +664,7 @@ function VS:CreateTriggerSlider(parent, name, label, channelKey, workingTable, m
         local val = math_floor(invertedValue * 100 + 0.5) / 100
 
         workingTable.volumes[channelKey] = val
-        self.valueText:SetText(math_floor(val * 100 + 0.5) .. "%")
+        self.valueText:SetText(VS:FormatVolumeValue(val))
     end)
 
     -- Push the value text and title up even further for more breathing room
@@ -783,7 +783,7 @@ function VS:CreateTriggerSlider(parent, name, label, channelKey, workingTable, m
         local currentVol = workingTable.volumes[channelKey] or 1
         self.isRefreshing = true
         self:SetValue(1 - currentVol)
-        self.valueText:SetText(math_floor(currentVol * 100 + 0.5) .. "%")
+        self.valueText:SetText(VS:FormatVolumeValue(currentVol))
         self.isRefreshing = false
         
         local ignored = workingTable.ignored and workingTable.ignored[channelKey]

--- a/VolumeSliders/VolumeSliders.toc
+++ b/VolumeSliders/VolumeSliders.toc
@@ -2,7 +2,7 @@
 ## Title: Volume Sliders
 ## Notes: Volume sliders for all sound channels
 ## Author: Sheldon Michaels
-## Version: 3.9.1
+## Version: 3.10.0
 ## SavedVariables: VolumeSlidersMMDB
 ## SavedVariablesPerCharacter:
 ## OptionalDeps:

--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -3,7 +3,7 @@
 **Database:** `VolumeSlidersMMDB`
 **Scope:** Global / Account-wide
 **Format:** Serialized Lua Table (Pseudo-JSON representation below)
-**Last Audited:** 2026-05-06 (SchemaVersion 8)
+**Last Audited:** 2026-05-12 (SchemaVersion 9)
 
 This document defines the exact shape of the saved variables used by Volume Sliders. It acts as the single source of truth for the data layer, distinguishing between user-configurable options, transient session states, and deprecated keys.
 
@@ -15,7 +15,7 @@ As of version 3.0.0, the monolithic flat-key structure has been deprecated in fa
 
 ```json
 {
-  "schemaVersion": 8,
+  "schemaVersion": 9,
 
   // ---------------------------------------------------------
   // 1. APPEARANCE & WINDOW STYLING
@@ -43,7 +43,8 @@ As of version 3.0.0, the monolithic flat-key structure has been deprecated in fa
     "highColor": "string",  // Enum (e.g., "White")
     "lowColor": "string",   // Enum (e.g., "White")
     "sampleSound": "number|string", // SoundKit ID for slider chimes
-    "sampleSoundMinimap": "number|string" // SoundKit ID for minimap chimes
+    "sampleSoundMinimap": "number|string", // SoundKit ID for minimap chimes
+    "volumeDisplayFormat": "string" // Enum: "percentage", "decimal", "decibel"
   },
 
   // ---------------------------------------------------------
@@ -270,3 +271,7 @@ Adds the `showEmoteSounds` toggle to the `toggles` namespace and injects it into
 ## Migration Contract (`Init.lua:Migrate_V7_to_V8`)
 
 Adds the `playSampleSound` and `playSampleSoundMinimap` booleans to the `toggles` namespace (default `false`), and the `sampleSound` and `sampleSoundMinimap` properties to the `appearance` namespace (default `856`) to support auditory feedback when sliders or the minimap icon are scrolled.
+
+## Migration Contract (`Init.lua:Migrate_V8_to_V9`)
+
+Adds the `appearance.volumeDisplayFormat` string enum (default `"percentage"`) to control how current volume values are rendered in the popup, minimap broker text, minimap tooltip, and preset editor sliders. Existing users retain percentage output until they choose a different format.

--- a/spec/Core_spec.lua
+++ b/spec/Core_spec.lua
@@ -16,8 +16,8 @@ describe("VolumeSliders Core Module", function()
         
         -- Mock dependencies that Core.lua expects to exist or call
         _G.VolumeSlidersMMDB = {
-            schemaVersion = 8,
-            appearance = { windowWidth = 375, windowHeight = 440, sampleSound = 856, sampleSoundMinimap = 850 },
+            schemaVersion = 9,
+            appearance = { windowWidth = 375, windowHeight = 440, sampleSound = 856, sampleSoundMinimap = 850, volumeDisplayFormat = "percentage" },
             layout = { sliderOrder = {}, footerOrder = {}, mouseActions = { sliders = {}, scrollWheel = {} } },
             toggles = { showMinimapTooltip = true, playSampleSound = true, playSampleSoundMinimap = true },
             channels = {},
@@ -48,6 +48,30 @@ describe("VolumeSliders Core Module", function()
         it("GetVolumeText should return percentage string", function()
             _G.SetCVar("Sound_MasterVolume", "0.45")
             assert.equal("45%", VS:GetVolumeText())
+        end)
+
+        it("FormatVolumeValue should return percentage strings by default", function()
+            assert.equal("80%", VS:FormatVolumeValue(0.8))
+            assert.equal("100%", VS:FormatVolumeValue(1.5))
+            assert.equal("0%", VS:FormatVolumeValue(-0.1))
+        end)
+
+        it("FormatVolumeValue should return fixed decimal strings", function()
+            _G.VolumeSlidersMMDB.appearance.volumeDisplayFormat = "decimal"
+            assert.equal("0.80", VS:FormatVolumeValue(0.8))
+            assert.equal("0.46", VS:FormatVolumeValue(0.455))
+        end)
+
+        it("FormatVolumeValue should return decibel strings", function()
+            _G.VolumeSlidersMMDB.appearance.volumeDisplayFormat = "decibel"
+            assert.equal("0.0 dB", VS:FormatVolumeValue(1))
+            assert.equal("-1.9 dB", VS:FormatVolumeValue(0.8))
+            assert.equal("-∞ dB", VS:FormatVolumeValue(0))
+        end)
+
+        it("FormatVolumeValue should fall back to percentage for unknown formats", function()
+            _G.VolumeSlidersMMDB.appearance.volumeDisplayFormat = "unknown"
+            assert.equal("80%", VS:FormatVolumeValue(0.8))
         end)
 
         it("AdjustVolume should clamp to [0, 1]", function()

--- a/spec/MigrationV6_spec.lua
+++ b/spec/MigrationV6_spec.lua
@@ -77,14 +77,15 @@ describe("Schema V5 to V6 Migration", function()
         _G.CreateFrame = realCreateFrame
     end)
 
-    it("should initialize enableDeviceVolumes and stamp version 6", function()
+    it("should initialize enableDeviceVolumes and stamp the latest schema version", function()
         local db = _G.VolumeSlidersMMDB
 
         -- Logic is executed during PLAYER_LOGIN
         initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
 
-        assert.are.equal(8, db.schemaVersion)
+        assert.are.equal(9, db.schemaVersion)
         assert.is_true(db.automation.enableDeviceVolumes)
+        assert.are.equal("percentage", db.appearance.volumeDisplayFormat)
     end)
 
     it("should not overwrite enableDeviceVolumes if already present", function()
@@ -94,7 +95,8 @@ describe("Schema V5 to V6 Migration", function()
         
         initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
 
-        assert.are.equal(8, db.schemaVersion)
+        assert.are.equal(9, db.schemaVersion)
         assert.is_false(db.automation.enableDeviceVolumes)
+        assert.are.equal("percentage", db.appearance.volumeDisplayFormat)
     end)
 end)

--- a/spec/MigrationV7_spec.lua
+++ b/spec/MigrationV7_spec.lua
@@ -85,8 +85,9 @@ describe("Schema V6 to V7 Migration", function()
         -- Logic is executed during PLAYER_LOGIN
         initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
 
-        assert.are.equal(8, db.schemaVersion)
+        assert.are.equal(9, db.schemaVersion)
         assert.is_false(db.toggles.showEmoteSounds)
+        assert.are.equal("percentage", db.appearance.volumeDisplayFormat)
         
         -- Check if it was injected at index 6 (before showOutput)
         assert.are.equal("showEmoteSounds", db.layout.footerOrder[6])
@@ -174,7 +175,7 @@ describe("Schema V6 to V7 Migration (empty footerOrder)", function()
         local db = _G.VolumeSlidersMMDB
         initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
 
-        assert.are.equal(8, db.schemaVersion)
+        assert.are.equal(9, db.schemaVersion)
         assert.are.equal(8, #db.layout.footerOrder)
         assert.are.equal("showZoneTriggers", db.layout.footerOrder[1])
         assert.are.equal("showEmoteSounds", db.layout.footerOrder[6])
@@ -266,7 +267,7 @@ describe("Schema V6 to V7 Migration (short footerOrder)", function()
         local db = _G.VolumeSlidersMMDB
         initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
 
-        assert.are.equal(8, db.schemaVersion)
+        assert.are.equal(9, db.schemaVersion)
         assert.are.equal("showEmoteSounds", db.layout.footerOrder[5])
         local n = 0
         for _ in ipairs(db.layout.footerOrder) do

--- a/spec/MigrationV9_spec.lua
+++ b/spec/MigrationV9_spec.lua
@@ -1,18 +1,18 @@
 -------------------------------------------------------------------------------
--- spec/MigrationV8_spec.lua
--- Tests the V7 to V8 database migration.
+-- spec/MigrationV9_spec.lua
+-- Tests the V8 to V9 database migration.
 -------------------------------------------------------------------------------
 
-describe("V7 to V8 Database Migration", function()
+describe("V8 to V9 Database Migration", function()
     local VS
     local initFrameScript
 
     before_each(function()
         VS = {}
 
-        -- Mock a pristine V7 Database
+        -- Mock a pristine V8 Database
         _G.VolumeSlidersMMDB = {
-            schemaVersion = 7,
+            schemaVersion = 8,
             toggles = {},
             appearance = {},
             minimap = {},
@@ -50,34 +50,22 @@ describe("V7 to V8 Database Migration", function()
         _G.CreateFrame = realCreateFrame
     end)
 
-    it("should initialize playSampleSound to false and sampleSound to 856, and stamp the latest schema version", function()
+    it("should initialize volumeDisplayFormat to percentage and stamp version 9", function()
         local db = _G.VolumeSlidersMMDB
-        
-        -- Logic is executed during PLAYER_LOGIN
+
         initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
 
         assert.are.equal(9, db.schemaVersion)
-        assert.is_false(db.toggles.playSampleSound)
-        assert.is_false(db.toggles.playSampleSoundMinimap)
-        assert.are.equal(856, db.appearance.sampleSound)
-        assert.are.equal(856, db.appearance.sampleSoundMinimap)
         assert.are.equal("percentage", db.appearance.volumeDisplayFormat)
     end)
 
-    it("should not overwrite existing sample sound variables if migrating from higher versions or manually set", function()
+    it("should not overwrite an existing volumeDisplayFormat", function()
         local db = _G.VolumeSlidersMMDB
-        db.toggles.playSampleSound = true
-        db.appearance.sampleSound = "Sound/MyCustomSound.ogg"
-        
+        db.appearance.volumeDisplayFormat = "decibel"
+
         initFrameScript({ UnregisterEvent = function() end }, "PLAYER_LOGIN")
 
         assert.are.equal(9, db.schemaVersion)
-        assert.is_true(db.toggles.playSampleSound)
-        assert.are.equal("Sound/MyCustomSound.ogg", db.appearance.sampleSound)
-        assert.are.equal("percentage", db.appearance.volumeDisplayFormat)
-        
-        -- Minimap should have defaulted since we didn't mock it
-        assert.is_false(db.toggles.playSampleSoundMinimap)
-        assert.are.equal(856, db.appearance.sampleSoundMinimap)
+        assert.are.equal("decibel", db.appearance.volumeDisplayFormat)
     end)
 end)

--- a/spec/Migration_spec.lua
+++ b/spec/Migration_spec.lua
@@ -113,7 +113,8 @@ describe("V1 to V2 Database Migration", function()
         local db = _G.VolumeSlidersMMDB
 
         -- Assert Version Label
-        assert.are.equal(8, db.schemaVersion)
+        assert.are.equal(9, db.schemaVersion)
+        assert.are.equal("percentage", db.appearance.volumeDisplayFormat)
 
         -- Assert transient keys are completely purged
         assert.is_nil(db.originalVolumes)


### PR DESCRIPTION
## Summary
- Adds a Slider Customization setting for percentage, decimal, and decibel volume displays.
- Centralizes volume value formatting so popup sliders, preset sliders, broker text, and minimap tooltip rows stay consistent.
- Bumps the release to v3.10.0 and adds the saved-variable schema v9 migration plus coverage.

## Public Changelog
### Added
- **Volume Display Formats**: Added a new Slider Customization option to display volume values as percentages, decimals, or decibels across the popup window, minimap broker text, minimap tooltip, and preset editor sliders.

## Test Plan
- `luacheck VolumeSliders spec`
- `busted . --verbose`
- Manual in-game testing confirmed the display formats work.

Closes #16
