### PR TITLE
docs: explicitly document .agents/artifacts/ as ignored artifacts folder

### DIFF
--- a/.agents/skills/wow-release/SKILL.md
+++ b/.agents/skills/wow-release/SKILL.md
@@ -21,7 +21,7 @@ compatibility: Requires git, GitHub access, gh or GitHub MCP, and repository val
 11. Stop until the user confirms the PR was merged.
 12. After merge confirmation, fetch/prune, fast-forward local `master`, verify the release version on `master`, and clean up the local dev branch.
 13. Ask explicit permission before creating or pushing the annotated release tag for the exact version.
-14. Finally, clean up agent scratch files and temporary artifacts created during the completed branch's work. Always verify the contents of a file before deleting it to ensure it is safe to remove (e.g., delete scratch PR bodies or temporary logs, but preserve persistent history, documentation, and screenshots).
+14. Finally, clean up agent scratch files and temporary artifacts in `.agents/artifacts/` created during the completed branch's work. Always verify the contents of a file before deleting it to ensure it is safe to remove (e.g., delete scratch PR bodies or temporary logs, but preserve persistent history, documentation, and screenshots).
 
 ## Hard Constraints
 

--- a/.agents/workflows/release-pr.md
+++ b/.agents/workflows/release-pr.md
@@ -18,4 +18,4 @@ Use this workflow when the user asks to prepare a release, or when a normal user
 10. Instruct the human user to manually squash and merge the PR on GitHub.
 11. Stop until the user confirms the PR has been merged.
 12. After user confirmation, fetch/prune, fast-forward local `master`, verify `HEAD` and release metadata, clean up the local dev branch, and ask explicit permission before creating any annotated release tag.
-13. After tags are created and pushed, clean up untracked artifacts (`.gemini/artifacts`, `.cursor/artifacts`) and temporary files in `local_dev_assets/` (e.g. scratch PR bodies).
+13. After tags are created and pushed, clean up untracked artifacts (`.agents/artifacts/`) and temporary files in `local_dev_assets/` (e.g. scratch PR bodies).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ This is the universal, tracked instruction file for AI coding agents working on 
 WoW-Volume-Sliders/
 |-- AGENTS.md                  # universal tracked agent baseline
 |-- .agents/                   # tracked Antigravity personas, skills, workflows
+|   `-- artifacts/             # ignored agent execution artifacts (plans, logs, reports)
 |-- .cursor/rules/             # tracked Cursor project rules
 |-- .github/workflows/         # CI/CD
 |-- docs/                      # architecture, schema, testing, release, AI docs
@@ -84,7 +85,7 @@ Documentation-only changes do not require the Lua test suite unless they alter d
 - **Cursor:** `.cursor/rules/*.mdc` contains short, scoped project rules. Cursor rules should point back to this file or committed docs instead of copying large sections.
 - **Antigravity:** `.agents/agents.md`, `.agents/skills/`, and `.agents/workflows/` define project personas and lifecycle commands.
   - Workflows use named personas (`@planner`, `@api-researcher`, `@implementer`, `@validator`, `@debugger`, `@release-manager`) defined in `.agents/agents.md`.
-- **Artifacts:** Generated planning, research, implementation, validation, or release artifacts belong in ignored artifact directories unless the user explicitly asks to commit them.
+- **Artifacts:** Generated planning, research, implementation, validation, or release artifacts belong in the ignored `.agents/artifacts/` directory unless the user explicitly asks to commit them.
 
 ## Windows and GitHub CLI
 

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -41,14 +41,14 @@ If CI or workflow files change, review `docs/CI_AND_RELEASE.md` and ensure the d
 - Create or use a `dev/*` branch for repository modifications.
 - For PR-bound work, start from current `origin/master` unless the user explicitly asks to stack on another branch.
 - Do not write implementation code before the boundaries are clear.
-- For large or risky work, produce an architecture artifact in an ignored artifact directory.
+- For large or risky work, produce an architecture artifact in the ignored `.agents/artifacts/` directory.
 
 ### API Discovery
 
 - Verify patch-accurate WoW API signatures before using unfamiliar functions or events.
 - Research taint, protected frame, combat-lockdown, CVar, and settings behavior when relevant.
 - Use the `wow-api` MCP server tools for signature verification when available. Supplement with reputable live documentation relevant to the current WoW Retail version.
-- Capture verified signatures and risks in an ignored research artifact for complex changes.
+- Capture verified signatures and risks in an ignored research artifact in `.agents/artifacts/` for complex changes.
 
 ### Implementation
 
@@ -93,7 +93,7 @@ If CI or workflow files change, review `docs/CI_AND_RELEASE.md` and ensure the d
 - All merges into `master` must go through a GitHub PR.
 - The agent must not merge PRs.
 - After the human confirms a squash merge, fetch/prune, fast-forward local `master`, delete the local dev branch, verify the release version on `master`, and ask explicit permission before creating or pushing the annotated release tag for that exact version.
-- Once tags are pushed, clean up agent scratch files and temporary artifacts created during the completed branch's work. Always verify the contents of a file before deleting it to ensure it is safe to remove (e.g., delete scratch PR bodies or temporary logs, but preserve persistent history, documentation, and screenshots).
+- Once tags are pushed, clean up agent scratch files and temporary artifacts in `.agents/artifacts/` created during the completed branch's work. Always verify the contents of a file before deleting it to ensure it is safe to remove (e.g., delete scratch PR bodies or temporary logs, but preserve persistent history, documentation, and screenshots).
 
 ## Saved Variable Rules
 
@@ -126,7 +126,7 @@ Do not change persisted boundaries through implicit defaults alone.
 
 - Project personas, skills, and workflows live in `.agents/`.
 - Skills should prefer `SKILL.md` directory packages with `name` and `description` metadata.
-- Workflows should orchestrate the lifecycle phases and save generated artifacts to ignored artifact paths.
+- Workflows should orchestrate the lifecycle phases and save generated artifacts to the `.agents/artifacts/` directory.
 
 ### Local Overrides
 

--- a/docs/CI_AND_RELEASE.md
+++ b/docs/CI_AND_RELEASE.md
@@ -66,7 +66,7 @@ After the maintainer confirms the merge:
 3. Verify `HEAD`, `CHANGELOG.md`, and `VolumeSliders/VolumeSliders.toc` match the intended release version.
 4. Delete the merged local `dev/*` branch. Squash merges usually require `git branch -D` because the exact branch commit is not an ancestor of `master`.
 5. Ask explicit permission before creating and pushing the annotated release tag for the exact version, for example `v3.9.1`.
-6. Finally, clean up agent scratch files and temporary artifacts created during the completed branch's work. Always verify the contents of a file before deleting it to ensure it is safe to remove (e.g., delete scratch PR bodies or temporary logs, but preserve persistent history, documentation, and screenshots).
+6. Finally, clean up agent scratch files and temporary artifacts in `.agents/artifacts/` created during the completed branch's work. Always verify the contents of a file before deleting it to ensure it is safe to remove (e.g., delete scratch PR bodies or temporary logs, but preserve persistent history, documentation, and screenshots).
 
 ## Local Equivalents
 


### PR DESCRIPTION
This pull request updates the documentation, guidelines, workflows, and skills to explicitly specify `.agents/artifacts/` as the canonical ignored directory for agent-generated artifacts. This aligns the repository map and cleanup steps with actual practice.